### PR TITLE
data: ajout de nouveaux minerais pour la v0.3.12

### DIFF
--- a/src/data/minerais.json
+++ b/src/data/minerais.json
@@ -58,5 +58,25 @@
     "frequence": "rare",
     "niveauSecteurMinimal": 0.1,
     "description": "Minerai précieux, peu fréquent, au fort potentiel commercial."
+  },
+  {
+    "id": "magnetite_nickelifere",
+    "nom": "Magnétite nickélifère",
+    "abreviation": "mag.nic.",
+    "icone": "⬟",
+    "prixUnitaire": 8,
+    "frequence": "rare",
+    "niveauSecteurMinimal": 0.2,
+    "description": "Minerai métallique dense, recherché pour ses usages sidérurgiques et alliages techniques."
+  },
+  {
+    "id": "chromite",
+    "nom": "Chromite",
+    "abreviation": "chro.",
+    "icone": "✶",
+    "prixUnitaire": 10,
+    "frequence": "tres_rare",
+    "niveauSecteurMinimal": 0.1,
+    "description": "Minerai rare riche en chrome, très apprécié dans les filières industrielles avancées."
   }
 ]

--- a/src/game/donneesInitiales.js
+++ b/src/game/donneesInitiales.js
@@ -1,11 +1,16 @@
 import { donneesVaisseaux } from './dataVaisseaux'
+import { donneesMinerais } from './dataMinerais'
+
+function creerStockMineraisInitial() {
+  return Object.fromEntries(donneesMinerais.map((minerai) => [minerai.id, 0]))
+}
 
 export function creerEtatInitialJeu() {
   const vaisseauDepart = donneesVaisseaux.find((vaisseau) => vaisseau.id === 'hw_mule')
 
   return {
     meta: {
-      version: '0.3.11',
+      version: '0.3.12',
       auteur: 'Kaemyll',
       annee: 2026,
     },
@@ -13,14 +18,7 @@ export function creerEtatInitialJeu() {
     ressources: {
       credits: 0,
       carburant: vaisseauDepart.carburantMax,
-      minerais: {
-        roche_carbonee: 0,
-        poussiere_silicatee: 0,
-        olivine: 0,
-        pyroxene: 0,
-        fer_nickel_brut: 0,
-        cobalt_natif: 0,
-      },
+      minerais: creerStockMineraisInitial(),
     },
 
     vaisseau: {


### PR DESCRIPTION
## Objectif

Première étape de la v0.3.12 : enrichir le contenu minier du jeu.

## Contenu

- ajout de la magnétite nickélifère
- ajout de la chromite
- préparation des futurs secteurs et répartitions minières
- mise à jour des stocks initiaux si nécessaire

## Vérifications

- les nouveaux minerais sont présents dans les données
- l’interface continue de fonctionner
- aucun système existant n’est cassé