### PR TITLE
feat(v0.3.12): affiner les modificateurs économiques des secteurs

### DIFF
--- a/src/data/minerais.json
+++ b/src/data/minerais.json
@@ -4,7 +4,7 @@
     "nom": "Roche carbonée",
     "abreviation": "roc.carb.",
     "icone": "◆",
-    "prixUnitaire": 1,
+    "prixUnitaire": 10,
     "frequence": "ultra_commune",
     "niveauSecteurMinimal": 1.0,
     "description": "Roche pauvre et abondante, très peu valorisée."
@@ -14,7 +14,7 @@
     "nom": "Poussière silicatée",
     "abreviation": "pou.sili.",
     "icone": "◇",
-    "prixUnitaire": 2,
+    "prixUnitaire": 16,
     "frequence": "ultra_commune",
     "niveauSecteurMinimal": 1.0,
     "description": "Résidu minéral très commun, peu coûteux mais facile à extraire."
@@ -24,7 +24,7 @@
     "nom": "Olivine",
     "abreviation": "oliv.",
     "icone": "⬡",
-    "prixUnitaire": 2,
+    "prixUnitaire": 24,
     "frequence": "commune",
     "niveauSecteurMinimal": 1.0,
     "description": "Silicate courant, utilisé dans plusieurs chaînes industrielles simples."
@@ -34,7 +34,7 @@
     "nom": "Pyroxène",
     "abreviation": "pyro.",
     "icone": "⬢",
-    "prixUnitaire": 3,
+    "prixUnitaire": 36,
     "frequence": "commune",
     "niveauSecteurMinimal": 0.6,
     "description": "Minerai plus intéressant, apprécié pour certaines applications industrielles."
@@ -44,7 +44,7 @@
     "nom": "Fer-nickel brut",
     "abreviation": "fer.nic.",
     "icone": "■",
-    "prixUnitaire": 4,
+    "prixUnitaire": 58,
     "frequence": "peu_commune",
     "niveauSecteurMinimal": 0.3,
     "description": "Métal brut plus rentable, recherché pour les usages industriels lourds."
@@ -54,7 +54,7 @@
     "nom": "Cobalt natif",
     "abreviation": "cob.nat.",
     "icone": "✦",
-    "prixUnitaire": 6,
+    "prixUnitaire": 95,
     "frequence": "rare",
     "niveauSecteurMinimal": 0.1,
     "description": "Minerai précieux, peu fréquent, au fort potentiel commercial."
@@ -64,7 +64,7 @@
     "nom": "Magnétite nickélifère",
     "abreviation": "mag.nic.",
     "icone": "⬟",
-    "prixUnitaire": 8,
+    "prixUnitaire": 150,
     "frequence": "rare",
     "niveauSecteurMinimal": 0.2,
     "description": "Minerai métallique dense, recherché pour ses usages sidérurgiques et alliages techniques."
@@ -74,7 +74,7 @@
     "nom": "Chromite",
     "abreviation": "chro.",
     "icone": "✶",
-    "prixUnitaire": 10,
+    "prixUnitaire": 240,
     "frequence": "tres_rare",
     "niveauSecteurMinimal": 0.1,
     "description": "Minerai rare riche en chrome, très apprécié dans les filières industrielles avancées."

--- a/src/data/secteurs.json
+++ b/src/data/secteurs.json
@@ -16,16 +16,16 @@
         "atelier": true
       },
       "economie": {
-        "coutCarburantParUnite": 1,
+        "coutCarburantParUnite": 10,
         "modificateursMinerais": [
-          { "idMinerai": "roche_carbonee", "modificateur": 0.75 },
-          { "idMinerai": "poussiere_silicatee", "modificateur": 0.82 },
-          { "idMinerai": "olivine", "modificateur": 0.9 },
-          { "idMinerai": "pyroxene", "modificateur": 1.08 },
-          { "idMinerai": "fer_nickel_brut", "modificateur": 1.2 },
-          { "idMinerai": "cobalt_natif", "modificateur": 1.35 },
-          { "idMinerai": "magnetite_nickelifere", "modificateur": 1.18 },
-          { "idMinerai": "chromite", "modificateur": 1.22 }
+          { "idMinerai": "roche_carbonee", "modificateur": 0.92 },
+          { "idMinerai": "poussiere_silicatee", "modificateur": 0.95 },
+          { "idMinerai": "olivine", "modificateur": 0.97 },
+          { "idMinerai": "pyroxene", "modificateur": 1.03 },
+          { "idMinerai": "fer_nickel_brut", "modificateur": 1.05 },
+          { "idMinerai": "cobalt_natif", "modificateur": 1.08 },
+          { "idMinerai": "magnetite_nickelifere", "modificateur": 1.1 },
+          { "idMinerai": "chromite", "modificateur": 1.12 }
         ]
       }
     },
@@ -52,16 +52,16 @@
         "atelier": false
       },
       "economie": {
-        "coutCarburantParUnite": 1,
+        "coutCarburantParUnite": 11,
         "modificateursMinerais": [
-          { "idMinerai": "roche_carbonee", "modificateur": 0.7 },
-          { "idMinerai": "poussiere_silicatee", "modificateur": 0.92 },
-          { "idMinerai": "olivine", "modificateur": 1.05 },
-          { "idMinerai": "pyroxene", "modificateur": 1.18 },
-          { "idMinerai": "fer_nickel_brut", "modificateur": 1.08 },
-          { "idMinerai": "cobalt_natif", "modificateur": 1.15 },
-          { "idMinerai": "magnetite_nickelifere", "modificateur": 1.12 },
-          { "idMinerai": "chromite", "modificateur": 1.1 }
+          { "idMinerai": "roche_carbonee", "modificateur": 0.9 },
+          { "idMinerai": "poussiere_silicatee", "modificateur": 0.98 },
+          { "idMinerai": "olivine", "modificateur": 1.04 },
+          { "idMinerai": "pyroxene", "modificateur": 1.09 },
+          { "idMinerai": "fer_nickel_brut", "modificateur": 1.03 },
+          { "idMinerai": "cobalt_natif", "modificateur": 1.01 },
+          { "idMinerai": "magnetite_nickelifere", "modificateur": 0.98 },
+          { "idMinerai": "chromite", "modificateur": 0.95 }
         ]
       }
     },
@@ -88,16 +88,16 @@
         "atelier": true
       },
       "economie": {
-        "coutCarburantParUnite": 1,
+        "coutCarburantParUnite": 12,
         "modificateursMinerais": [
-          { "idMinerai": "roche_carbonee", "modificateur": 0.65 },
-          { "idMinerai": "poussiere_silicatee", "modificateur": 0.78 },
-          { "idMinerai": "olivine", "modificateur": 0.94 },
-          { "idMinerai": "pyroxene", "modificateur": 1.08 },
-          { "idMinerai": "fer_nickel_brut", "modificateur": 1.28 },
-          { "idMinerai": "cobalt_natif", "modificateur": 1.22 },
-          { "idMinerai": "magnetite_nickelifere", "modificateur": 1.34 },
-          { "idMinerai": "chromite", "modificateur": 1.18 }
+          { "idMinerai": "roche_carbonee", "modificateur": 0.88 },
+          { "idMinerai": "poussiere_silicatee", "modificateur": 0.92 },
+          { "idMinerai": "olivine", "modificateur": 0.98 },
+          { "idMinerai": "pyroxene", "modificateur": 1.06 },
+          { "idMinerai": "fer_nickel_brut", "modificateur": 1.14 },
+          { "idMinerai": "cobalt_natif", "modificateur": 1.08 },
+          { "idMinerai": "magnetite_nickelifere", "modificateur": 1.16 },
+          { "idMinerai": "chromite", "modificateur": 1.1 }
         ]
       }
     },
@@ -124,16 +124,16 @@
         "atelier": false
       },
       "economie": {
-        "coutCarburantParUnite": 1,
+        "coutCarburantParUnite": 13,
         "modificateursMinerais": [
-          { "idMinerai": "roche_carbonee", "modificateur": 0.68 },
-          { "idMinerai": "poussiere_silicatee", "modificateur": 0.8 },
-          { "idMinerai": "olivine", "modificateur": 0.95 },
-          { "idMinerai": "pyroxene", "modificateur": 1.12 },
-          { "idMinerai": "fer_nickel_brut", "modificateur": 1.22 },
-          { "idMinerai": "cobalt_natif", "modificateur": 1.18 },
-          { "idMinerai": "magnetite_nickelifere", "modificateur": 1.2 },
-          { "idMinerai": "chromite", "modificateur": 1.14 }
+          { "idMinerai": "roche_carbonee", "modificateur": 0.87 },
+          { "idMinerai": "poussiere_silicatee", "modificateur": 0.91 },
+          { "idMinerai": "olivine", "modificateur": 0.98 },
+          { "idMinerai": "pyroxene", "modificateur": 1.08 },
+          { "idMinerai": "fer_nickel_brut", "modificateur": 1.11 },
+          { "idMinerai": "cobalt_natif", "modificateur": 1.13 },
+          { "idMinerai": "magnetite_nickelifere", "modificateur": 1.09 },
+          { "idMinerai": "chromite", "modificateur": 1.04 }
         ]
       }
     },
@@ -160,16 +160,16 @@
         "atelier": false
       },
       "economie": {
-        "coutCarburantParUnite": 1,
+        "coutCarburantParUnite": 14,
         "modificateursMinerais": [
-          { "idMinerai": "roche_carbonee", "modificateur": 0.58 },
-          { "idMinerai": "poussiere_silicatee", "modificateur": 0.7 },
-          { "idMinerai": "olivine", "modificateur": 0.82 },
-          { "idMinerai": "pyroxene", "modificateur": 1.02 },
-          { "idMinerai": "fer_nickel_brut", "modificateur": 1.18 },
-          { "idMinerai": "cobalt_natif", "modificateur": 1.4 },
-          { "idMinerai": "magnetite_nickelifere", "modificateur": 1.38 },
-          { "idMinerai": "chromite", "modificateur": 1.45 }
+          { "idMinerai": "roche_carbonee", "modificateur": 0.85 },
+          { "idMinerai": "poussiere_silicatee", "modificateur": 0.89 },
+          { "idMinerai": "olivine", "modificateur": 0.95 },
+          { "idMinerai": "pyroxene", "modificateur": 1.03 },
+          { "idMinerai": "fer_nickel_brut", "modificateur": 1.1 },
+          { "idMinerai": "cobalt_natif", "modificateur": 1.16 },
+          { "idMinerai": "magnetite_nickelifere", "modificateur": 1.18 },
+          { "idMinerai": "chromite", "modificateur": 1.2 }
         ]
       }
     },
@@ -196,16 +196,16 @@
         "atelier": false
       },
       "economie": {
-        "coutCarburantParUnite": 1,
+        "coutCarburantParUnite": 15,
         "modificateursMinerais": [
-          { "idMinerai": "roche_carbonee", "modificateur": 0.6 },
-          { "idMinerai": "poussiere_silicatee", "modificateur": 0.72 },
-          { "idMinerai": "olivine", "modificateur": 0.84 },
-          { "idMinerai": "pyroxene", "modificateur": 1.0 },
-          { "idMinerai": "fer_nickel_brut", "modificateur": 1.15 },
-          { "idMinerai": "cobalt_natif", "modificateur": 1.32 },
-          { "idMinerai": "magnetite_nickelifere", "modificateur": 1.42 },
-          { "idMinerai": "chromite", "modificateur": 1.55 }
+          { "idMinerai": "roche_carbonee", "modificateur": 0.84 },
+          { "idMinerai": "poussiere_silicatee", "modificateur": 0.88 },
+          { "idMinerai": "olivine", "modificateur": 0.94 },
+          { "idMinerai": "pyroxene", "modificateur": 1.02 },
+          { "idMinerai": "fer_nickel_brut", "modificateur": 1.08 },
+          { "idMinerai": "cobalt_natif", "modificateur": 1.15 },
+          { "idMinerai": "magnetite_nickelifere", "modificateur": 1.2 },
+          { "idMinerai": "chromite", "modificateur": 1.24 }
         ]
       }
     },

--- a/src/data/vaisseaux.json
+++ b/src/data/vaisseaux.json
@@ -19,7 +19,7 @@
         "id": "soute",
         "nom": "Extension de soute",
         "description": "Augmente la capacité de stockage.",
-        "cout": 25,
+        "cout": 1000,
         "increment": 5,
         "valeurMax": 25
       },
@@ -27,7 +27,7 @@
         "id": "drones",
         "nom": "Baie à drones renforcée",
         "description": "Augmente le nombre maximal de drones embarqués.",
-        "cout": 35,
+        "cout": 1400,
         "increment": 1,
         "valeurMax": 4
       },
@@ -35,7 +35,7 @@
         "id": "carburant",
         "nom": "Réservoir auxiliaire",
         "description": "Augmente la capacité maximale de carburant.",
-        "cout": 30,
+        "cout": 1200,
         "increment": 5,
         "valeurMax": 20
       },
@@ -43,7 +43,7 @@
         "id": "extraction",
         "nom": "Tête d’extraction améliorée",
         "description": "Renforce légèrement le rendement minier du vaisseau.",
-        "cout": 40,
+        "cout": 1600,
         "increment": 1,
         "valeurMax": 3
       }
@@ -69,7 +69,7 @@
         "id": "soute",
         "nom": "Extension de soute",
         "description": "Augmente la capacité de stockage.",
-        "cout": 45,
+        "cout": 1800,
         "increment": 6,
         "valeurMax": 44
       },
@@ -77,7 +77,7 @@
         "id": "drones",
         "nom": "Baie à drones renforcée",
         "description": "Augmente le nombre maximal de drones embarqués.",
-        "cout": 55,
+        "cout": 2200,
         "increment": 1,
         "valeurMax": 5
       },
@@ -85,7 +85,7 @@
         "id": "carburant",
         "nom": "Réservoir auxiliaire",
         "description": "Augmente la capacité maximale de carburant.",
-        "cout": 50,
+        "cout": 2000,
         "increment": 4,
         "valeurMax": 22
       },
@@ -93,7 +93,7 @@
         "id": "extraction",
         "nom": "Tête d’extraction améliorée",
         "description": "Renforce légèrement le rendement minier du vaisseau.",
-        "cout": 65,
+        "cout": 2600,
         "increment": 1,
         "valeurMax": 4
       }
@@ -119,7 +119,7 @@
         "id": "soute",
         "nom": "Extension de soute",
         "description": "Augmente la capacité de stockage.",
-        "cout": 40,
+        "cout": 1750,
         "increment": 8,
         "valeurMax": 64
       },
@@ -127,7 +127,7 @@
         "id": "drones",
         "nom": "Baie à drones renforcée",
         "description": "Augmente le nombre maximal de drones embarqués.",
-        "cout": 60,
+        "cout": 2550,
         "increment": 1,
         "valeurMax": 2
       },
@@ -135,7 +135,7 @@
         "id": "carburant",
         "nom": "Réservoir auxiliaire",
         "description": "Augmente la capacité maximale de carburant.",
-        "cout": 45,
+        "cout": 1950,
         "increment": 4,
         "valeurMax": 24
       },
@@ -143,7 +143,7 @@
         "id": "extraction",
         "nom": "Tête d’extraction améliorée",
         "description": "Renforce légèrement le rendement minier du vaisseau.",
-        "cout": 70,
+        "cout": 2950,
         "increment": 1,
         "valeurMax": 2
       }
@@ -169,7 +169,7 @@
         "id": "soute",
         "nom": "Extension de soute",
         "description": "Augmente la capacité de stockage.",
-        "cout": 40,
+        "cout": 1700,
         "increment": 5,
         "valeurMax": 36
       },
@@ -177,7 +177,7 @@
         "id": "drones",
         "nom": "Baie à drones renforcée",
         "description": "Augmente le nombre maximal de drones embarqués.",
-        "cout": 55,
+        "cout": 2300,
         "increment": 1,
         "valeurMax": 4
       },
@@ -185,7 +185,7 @@
         "id": "carburant",
         "nom": "Réservoir auxiliaire",
         "description": "Augmente la capacité maximale de carburant.",
-        "cout": 45,
+        "cout": 1900,
         "increment": 4,
         "valeurMax": 20
       },
@@ -193,7 +193,7 @@
         "id": "extraction",
         "nom": "Tête d’extraction améliorée",
         "description": "Renforce légèrement le rendement minier du vaisseau.",
-        "cout": 60,
+        "cout": 2550,
         "increment": 1,
         "valeurMax": 3
       }


### PR DESCRIPTION
## Objectif
Rééquilibrer l’économie sectorielle en augmentant la granularité des prix et en affinant les modificateurs par secteur.

## Changements
- révision des prix unitaires des minerais
- révision des coûts d’amélioration des vaisseaux
- ajustement du coût du carburant selon le niveau de sécurité
- affinage des modificateurs économiques par secteur
- meilleure cohérence entre progression, logistique et spécialisation des hubs

## Effet attendu
- variations économiques plus lisibles
- meilleure finesse pour les futurs événements économiques
- rythme de progression plus propre