### PR TITLE
feat(v0.3.12): rééquilibrer le scanner et la génération des amas miniers

### DIFF
--- a/src/assets/styles/main.css
+++ b/src/assets/styles/main.css
@@ -843,6 +843,43 @@ select {
   opacity: 0.72;
 }
 
+.ops-badge-scan {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 88px;
+  padding: 0.22rem 0.65rem;
+  border-radius: 999px;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  border: 1px solid transparent;
+}
+
+.ops-badge-scan-faible {
+  color: #f5d7a1;
+  background: rgba(168, 104, 32, 0.18);
+  border-color: rgba(214, 146, 58, 0.35);
+}
+
+.ops-badge-scan-moyenne {
+  color: #b8d7ff;
+  background: rgba(46, 95, 160, 0.18);
+  border-color: rgba(92, 150, 220, 0.35);
+}
+
+.ops-badge-scan-bonne {
+  color: #b9f0c9;
+  background: rgba(39, 122, 73, 0.18);
+  border-color: rgba(86, 196, 124, 0.35);
+}
+
+.ops-badge-scan-neutre {
+  color: #c8d0da;
+  background: rgba(120, 132, 146, 0.14);
+  border-color: rgba(160, 172, 186, 0.22);
+}
+
 .ops-local-badge {
   display: flex;
   align-items: center;

--- a/src/components/OperationPanel.vue
+++ b/src/components/OperationPanel.vue
@@ -82,6 +82,56 @@ const statutCanon = computed(() => {
   return 'Prêt'
 })
 
+const typeScannerLabel = computed(() => {
+  const type = props.vaisseau?.scanner?.type || 'base'
+
+  if (type === 'standard') {
+    return 'Module standard'
+  }
+
+  if (type === 'avance') {
+    return 'Module avancé'
+  }
+
+  return 'Module de base'
+})
+
+const qualiteScanLabel = computed(() => {
+  const qualite = props.exploration?.siteActif?.qualiteScan
+
+  if (qualite === 'bonne') {
+    return 'Bonne'
+  }
+
+  if (qualite === 'moyenne') {
+    return 'Moyenne'
+  }
+
+  if (qualite === 'faible') {
+    return 'Faible'
+  }
+
+  return '—'
+})
+
+const qualiteScanClasse = computed(() => {
+  const qualite = props.exploration?.siteActif?.qualiteScan
+
+  if (qualite === 'bonne') {
+    return 'ops-badge-scan-bonne'
+  }
+
+  if (qualite === 'moyenne') {
+    return 'ops-badge-scan-moyenne'
+  }
+
+  if (qualite === 'faible') {
+    return 'ops-badge-scan-faible'
+  }
+
+  return 'ops-badge-scan-neutre'
+})
+
 const descriptionSiteActif = computed(() => {
   const site = props.exploration?.siteActif
   if (!site) {
@@ -182,7 +232,7 @@ function decrireDrone(drone) {
 
           <div class="ops-system-item">
             <span class="ops-system-name">Scanner</span>
-            <span class="ops-system-value">Module de base</span>
+            <span class="ops-system-value">{{ typeScannerLabel }}</span>
           </div>
 
           <div class="ops-system-item">
@@ -201,6 +251,13 @@ function decrireDrone(drone) {
       <div class="ops-system-item">
         <span class="ops-system-name">Amas actif</span>
         <span class="ops-system-value">{{ descriptionSiteActif }}</span>
+      </div>
+
+      <div v-if="exploration.siteActif" class="ops-system-item">
+        <span class="ops-system-name">Qualité du relevé</span>
+        <span class="ops-badge-scan" :class="qualiteScanClasse">
+          {{ qualiteScanLabel }}
+        </span>
       </div>
 
       <div class="action-group">
@@ -281,8 +338,8 @@ function decrireDrone(drone) {
     </section>
 
     <p class="panel-note">
-      En v0.3.9, un scan détecte un amas minier actif. Le minage manuel et les drones exploitent
-      désormais sa réserve locale jusqu’à épuisement.
+      Le scanner peut détecter un amas minier exploitable… ou ne rien trouver. La qualité du relevé
+      influence la réserve estimée et la composition du site.
     </p>
   </section>
 </template>

--- a/src/game/systemeExploration.js
+++ b/src/game/systemeExploration.js
@@ -5,24 +5,39 @@ import { ajouterAuJournal, faireTournerDrones } from './systemeMinage'
 import { avancerTemps } from './systemeTemps'
 import { verifierPanneSecheEtDeclencher } from './systemeAssistance'
 
-function tirerQualiteScan() {
+function tirerResultatScan(typeScanner = 'base') {
   const tirage = Math.random()
 
-  if (tirage < 0.3) return 'faible'
-  if (tirage < 0.75) return 'moyenne'
+  if (typeScanner === 'base') {
+    if (tirage < 0.15) return 'echec'
+    if (tirage < 0.5) return 'faible'
+    if (tirage < 0.85) return 'moyenne'
+    return 'bonne'
+  }
+
+  if (typeScanner === 'standard') {
+    if (tirage < 0.08) return 'echec'
+    if (tirage < 0.33) return 'faible'
+    if (tirage < 0.78) return 'moyenne'
+    return 'bonne'
+  }
+
+  if (tirage < 0.1) return 'echec'
+  if (tirage < 0.45) return 'faible'
+  if (tirage < 0.8) return 'moyenne'
   return 'bonne'
 }
 
 function tirerReserveDepuisQualite(qualite) {
   if (qualite === 'faible') {
-    return 8 + Math.floor(Math.random() * 8) // 8-15
+    return 5 + Math.floor(Math.random() * 5) // 5-9
   }
 
   if (qualite === 'moyenne') {
-    return 16 + Math.floor(Math.random() * 13) // 16-28
+    return 10 + Math.floor(Math.random() * 8) // 10-17
   }
 
-  return 29 + Math.floor(Math.random() * 17) // 29-45
+  return 18 + Math.floor(Math.random() * 11) // 18-28
 }
 
 function tirerNomAmas(qualite) {
@@ -42,7 +57,19 @@ function tirerNomAmas(qualite) {
   return `${prefixe} ${suffixe}`
 }
 
-function genererCompositionLocale(secteur) {
+function obtenirAjustementsComposition(qualite) {
+  if (qualite === 'faible') {
+    return [5, 0, -15]
+  }
+
+  if (qualite === 'bonne') {
+    return [15, 5, -5]
+  }
+
+  return [10, 0, -10]
+}
+
+function genererCompositionLocale(secteur, qualite) {
   const repartition = [...(secteur?.repartitionMinerais || [])]
     .sort((a, b) => b.poids - a.poids)
     .slice(0, 3)
@@ -51,13 +78,22 @@ function genererCompositionLocale(secteur) {
     return []
   }
 
-  return repartition.map((entree, index) => {
-    const bonus = index === 0 ? 10 : index === 1 ? 0 : -10
-    return {
-      idMinerai: entree.idMinerai,
-      poids: Math.max(5, entree.poids + bonus),
-    }
-  })
+  const ajustements = obtenirAjustementsComposition(qualite)
+
+  return repartition.map((entree, index) => ({
+    idMinerai: entree.idMinerai,
+    poids: Math.max(5, entree.poids + (ajustements[index] ?? 0)),
+  }))
+}
+
+function obtenirTypeScanner(etat) {
+  return etat?.vaisseau?.scanner?.type || 'base'
+}
+
+function formaterComposition(composition) {
+  return composition
+    .map((c) => donneesMinerais.find((m) => m.id === c.idMinerai)?.abreviation || c.idMinerai)
+    .join(', ')
 }
 
 export function scannerAmasMinier() {
@@ -81,18 +117,40 @@ export function scannerAmasMinier() {
     return
   }
 
+  const ancienSite = etat.exploration?.siteActif || null
+  const typeScanner = obtenirTypeScanner(etat)
+
   avancerTemps(1)
 
   const secteur = donneesSecteurs.find((s) => s.id === etat.secteurCourant.id)
-  const qualiteScan = tirerQualiteScan()
-  const reserve = tirerReserveDepuisQualite(qualiteScan)
-  const composition = genererCompositionLocale(secteur)
+  const resultatScan = tirerResultatScan(typeScanner)
+
+  if (resultatScan === 'echec') {
+    etat.exploration.siteActif = null
+
+    faireTournerDrones()
+    verifierPanneSecheEtDeclencher()
+
+    if (ancienSite) {
+      ajouterAuJournal(
+        `Scan terminé : aucun amas exploitable détecté. Le relevé précédent (${ancienSite.nom}) est abandonné.`,
+        'evenements',
+      )
+      return
+    }
+
+    ajouterAuJournal('Scan terminé : aucun amas exploitable détecté dans la zone.', 'evenements')
+    return
+  }
+
+  const reserve = tirerReserveDepuisQualite(resultatScan)
+  const composition = genererCompositionLocale(secteur, resultatScan)
 
   etat.exploration.siteActif = {
     id: etat.exploration.prochainSiteId,
-    nom: tirerNomAmas(qualiteScan),
+    nom: tirerNomAmas(resultatScan),
     type: 'amas_minier',
-    qualiteScan,
+    qualiteScan: resultatScan,
     reserveTotale: reserve,
     reserveRestante: reserve,
     composition,
@@ -103,12 +161,18 @@ export function scannerAmasMinier() {
   faireTournerDrones()
   verifierPanneSecheEtDeclencher()
 
-  const nomsMinerais = composition
-    .map((c) => donneesMinerais.find((m) => m.id === c.idMinerai)?.abreviation || c.idMinerai)
-    .join(', ')
+  const nomsMinerais = formaterComposition(composition)
+
+  if (ancienSite) {
+    ajouterAuJournal(
+      `Scan terminé : ${etat.exploration.siteActif.nom} détecté (${resultatScan}). Réserve estimée ${reserve}. Composition : ${nomsMinerais}. L’ancien relevé (${ancienSite.nom}) est remplacé.`,
+      'evenements',
+    )
+    return
+  }
 
   ajouterAuJournal(
-    `Scan terminé : ${etat.exploration.siteActif.nom} détecté. Réserve estimée ${reserve}. Composition : ${nomsMinerais}.`,
+    `Scan terminé : ${etat.exploration.siteActif.nom} détecté (${resultatScan}). Réserve estimée ${reserve}. Composition : ${nomsMinerais}.`,
     'evenements',
   )
 }

--- a/src/game/systemeMinage.js
+++ b/src/game/systemeMinage.js
@@ -68,12 +68,19 @@ function verifierSiteActifExploitable() {
   const site = etat.exploration?.siteActif
 
   if (!site) {
-    ajouterAuJournal('Aucun amas minier actif. Un scan est requis.', 'evenements')
+    ajouterAuJournal(
+      '⚠ Aucun amas minier actif. Lancez un nouveau scan pour reprendre l’extraction.',
+      'evenements',
+      'alerte',
+    )
     return false
   }
 
-  if (site.reserveRestante <= 0) {
-    ajouterAuJournal('L’amas minier actif est épuisé. Un nouveau scan est requis.', 'evenements')
+  if (site.reserveRestante <= 0) {ajouterAuJournal(
+    '⚠ L’amas minier actif est épuisé. Un nouveau scan est requis.',
+    'evenements',
+    'alerte',
+  )
     etat.exploration.siteActif = null
     return false
   }
@@ -92,7 +99,11 @@ function consommerReserveSite(quantite = 1) {
   site.reserveRestante = Math.max(0, site.reserveRestante - quantite)
 
   if (site.reserveRestante === 0) {
-    ajouterAuJournal(`L’amas minier actif ${site.nom} est désormais épuisé.`, 'evenements')
+    ajouterAuJournal(
+      `⚠ ${site.nom} est épuisé. Nouveau scan requis pour détecter un autre amas.`,
+      'evenements',
+      'alerte',
+    )
     etat.exploration.siteActif = null
   }
 }
@@ -120,7 +131,11 @@ export function minerMineraiManuellement() {
   }
 
   if (etat.vaisseau.soute >= etat.vaisseau.souteMax) {
-    ajouterAuJournal('Soute pleine. Impossible de miner.', 'evenements')
+    ajouterAuJournal(
+      '⚠ Soute pleine : extraction impossible. Retour à la station ou vente requis.',
+      'evenements',
+      'alerte',
+    )
     return
   }
 
@@ -326,7 +341,11 @@ export function faireTournerDrones() {
 
       if (drone.ticksRechargeRestants === 0) {
         drone.autonomieRestante = 8
-        ajouterAuJournal(`Drone #${drone.id} recharge terminée. Drone prêt.`, 'evenements')
+        ajouterAuJournal(
+          `✓ Drone #${drone.id} rechargé et prêt à être redéployé.`,
+          'evenements',
+          'info',
+        )
       }
 
       continue
@@ -363,8 +382,9 @@ export function faireTournerDrones() {
     if (etat.exploration.siteActif.reserveRestante <= 0) {
       etat.exploration.siteActif = null
       ajouterAuJournal(
-        'L’amas minier actif est épuisé. Les drones cessent leur extraction.',
+        '⚠ L’amas minier actif est épuisé. Les drones cessent leur extraction. Nouveau scan requis.',
         'evenements',
+        'alerte',
       )
       return
     }


### PR DESCRIPTION
## Objectif
Rééquilibrer le scanner et la génération des amas miniers afin de rendre la prospection plus lisible, moins permissive et plus intéressante en jeu.

## Changements
- ajout d’une possibilité d’échec du scan pour les scanners de base
- révision des probabilités de qualité des relevés
- réduction et rééquilibrage des réserves des amas miniers
- influence de la qualité du scan sur la composition des amas
- amélioration de l’affichage dans le panneau Opérations
- ajout d’une meilleure visibilité de la qualité du relevé
- amélioration des logs liés à l’épuisement des amas, à la soute pleine et à la disponibilité des drones

## Effet attendu
- scans plus crédibles et moins automatiques
- meilleure lisibilité de la boucle de prospection
- amas plus intéressants selon la qualité du relevé
- feedback joueur plus clair pendant l’extraction