### PR TITLE
feat(v0.3.12): synchroniser automatiquement l’UI station/opérations a…

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -35,7 +35,7 @@ const etat = reactive({})
 
 function creerEtatUIInitial() {
   return {
-    modeActif: 'operations',
+    modeActif: 'station',
     sousModeStation: 'commerce',
   }
 }
@@ -78,6 +78,18 @@ function normaliserSousModeStation() {
   ui.sousModeStation = 'commerce'
 }
 
+function synchroniserModeActifAvecPositionLocale() {
+  if (etat.positionLocale === 'station') {
+    ui.modeActif = 'station'
+    normaliserSousModeStation()
+    return
+  }
+
+  if (etat.positionLocale === 'operations') {
+    ui.modeActif = 'operations'
+  }
+}
+
 function synchroniserEtat() {
   const etatCourant = structuredClone(recupererEtatJeu())
 
@@ -87,7 +99,7 @@ function synchroniserEtat() {
 
   Object.assign(etat, etatCourant)
 
-  normaliserSousModeStation()
+  synchroniserModeActifAvecPositionLocale()
 }
 
 function gererMinageManuel() {
@@ -151,15 +163,28 @@ function gererAmelioration(idAmelioration) {
 }
 
 function gererAllerOperations() {
+  const positionAvant = etat.positionLocale
+
   allerEnZoneOperations()
   sauvegarderJeu()
   synchroniserEtat()
+
+  if (positionAvant !== etat.positionLocale && etat.positionLocale === 'operations') {
+    ui.modeActif = 'operations'
+  }
 }
 
 function gererRetourStation() {
+  const positionAvant = etat.positionLocale
+
   retourALaStation()
   sauvegarderJeu()
   synchroniserEtat()
+
+  if (positionAvant !== etat.positionLocale && etat.positionLocale === 'station') {
+    ui.modeActif = 'station'
+    normaliserSousModeStation()
+  }
 }
 
 function gererReinitialisation() {
@@ -281,6 +306,7 @@ onUnmounted(() => {
             @ravitailler="gererRavitaillement"
             @acheter-drone="gererAchatDrone"
             @retour-station="gererRetourStation"
+            @aller-operations="gererAllerOperations"
           >
             <template #atelier>
               <UpgradePanel

--- a/src/assets/styles/main.css
+++ b/src/assets/styles/main.css
@@ -685,6 +685,18 @@ select {
   line-height: 1.16;
 }
 
+.action-group--station-launch {
+  margin-bottom: 10px;
+  justify-content: flex-start;
+}
+
+.action-group--station-launch button {
+  min-height: 36px;
+  min-width: 260px;
+  max-width: 320px;
+  padding-inline: 16px;
+}
+
 /* =========================================================
    14. ATELIER / AMÉLIORATIONS
    ========================================================= */

--- a/src/components/StationServicesPanel.vue
+++ b/src/components/StationServicesPanel.vue
@@ -39,6 +39,7 @@ const emit = defineEmits([
   'vendre',
   'ravitailler',
   'acheter-drone',
+  'aller-operations',
   'retour-station',
 ])
 
@@ -69,6 +70,9 @@ const coutDroneMinier = computed(() => props.economie?.coutDroneMinier ?? 400)
     <div class="station-services-header">
       <h2>⌘ Services de station</h2>
       <p class="station-services-subtitle">{{ station.nom }} — {{ station.type }}</p>
+    </div>
+    <div v-if="positionLocale === 'station'" class="action-group action-group--station-launch">
+      <button @click="emit('aller-operations')">Rejoindre la zone d’opérations</button>
     </div>
 
     <template v-if="positionLocale !== 'station'">

--- a/src/game/donneesInitiales.js
+++ b/src/game/donneesInitiales.js
@@ -26,6 +26,7 @@ export function creerEtatInitialJeu() {
       nom: vaisseauDepart.nom,
       constructeur: vaisseauDepart.constructeur,
       coque: vaisseauDepart.coqueMax,
+
       coqueMax: vaisseauDepart.coqueMax,
       soute: 0,
       souteMax: vaisseauDepart.souteMax,


### PR DESCRIPTION
- ajout du basculement automatique vers le panneau Station lors du retour à la station
- ajout d’un bouton local “Rejoindre la zone d’opérations” dans StationServicesPanel
- synchronisation de ui.modeActif avec etat.positionLocale au chargement et après resynchronisation d’état
- ajustement visuel du bouton d’accès aux opérations depuis la station