### PR TITLE
v0.3.14 - feat(coque) : gérer l’intégrité de coque individuellement par vaisseau

### DIFF
--- a/src/game/donneesInitiales.js
+++ b/src/game/donneesInitiales.js
@@ -20,8 +20,9 @@ function creerInstanceVaisseauDepuisModele(modele) {
     dronesMiniersMax: modele.dronesMiniersMax,
     carburant: modele.carburantMax,
     carburantMax: modele.carburantMax,
-    scanner: structuredClone(modele.scanner),
+    scanner: structuredClone(modele.scanner || {}),
     ameliorations: structuredClone(modele.ameliorations || []),
+    ameliorationsMax: structuredClone(modele.ameliorationsMax || {}),
   }
 }
 
@@ -31,7 +32,7 @@ export function creerEtatInitialJeu() {
 
   return {
     meta: {
-      version: '0.3.13/release_finale',
+      version: '0.3.14',
       auteur: 'Kaemyll',
       annee: 2026,
     },
@@ -59,8 +60,9 @@ export function creerEtatInitialJeu() {
       puissanceMiniere: vaisseauDepart.puissanceMiniere,
       dronesMiniersMax: vaisseauDepart.dronesMiniersMax,
       carburantMax: vaisseauDepart.carburantMax,
-      scanner: structuredClone(vaisseauDepart.scanner),
-      ameliorations: structuredClone(vaisseauDepart.ameliorations),
+      scanner: structuredClone(vaisseauDepart.scanner || {}),
+      ameliorations: structuredClone(vaisseauDepart.ameliorations || []),
+      ameliorationsMax: structuredClone(vaisseauDepart.ameliorationsMax || {}),
     },
 
     industrie: {

--- a/src/game/systemeAmeliorations.js
+++ b/src/game/systemeAmeliorations.js
@@ -11,8 +11,9 @@ function recupererSecteurCourant() {
 
 function recupererModeleVaisseau() {
   const etat = recupererEtatJeu()
+  const identifiantModele = etat.vaisseau?.modeleId || etat.vaisseau?.id
 
-  return donneesVaisseaux.find((vaisseau) => vaisseau.id === etat.vaisseau.id) || null
+  return donneesVaisseaux.find((vaisseau) => vaisseau.id === identifiantModele) || null
 }
 
 export function recupererListeAmeliorationsDisponibles() {

--- a/src/game/systemeSauvegarde.js
+++ b/src/game/systemeSauvegarde.js
@@ -43,10 +43,12 @@ export function chargerJeu() {
   try {
     const sauvegardeParsee = JSON.parse(sauvegardeBrute)
     const etatFusionne = fusionnerObjets(creerEtatInitialJeu(), sauvegardeParsee)
+
     hydraterEtatVaisseauxApresChargement(etatFusionne)
     remplacerEtatJeu(etatFusionne)
   } catch (erreur) {
     console.error('Erreur de chargement de sauvegarde :', erreur)
+
     const etatInitial = creerEtatInitialJeu()
     hydraterEtatVaisseauxApresChargement(etatInitial)
     remplacerEtatJeu(etatInitial)

--- a/src/game/systemeVaisseaux.js
+++ b/src/game/systemeVaisseaux.js
@@ -22,6 +22,10 @@ function ajouterAuJournal(message, categorie = 'evenements') {
   }
 }
 
+function bornerValeur(valeur, minimum, maximum) {
+  return Math.min(Math.max(valeur, minimum), maximum)
+}
+
 export function creerInstanceVaisseauDepuisModele(modeleId, suffixe = '001') {
   const modele = donneesVaisseaux.find((vaisseau) => vaisseau.id === modeleId)
 
@@ -43,8 +47,47 @@ export function creerInstanceVaisseauDepuisModele(modeleId, suffixe = '001') {
     dronesMiniersMax: modele.dronesMiniersMax,
     carburant: modele.carburantMax,
     carburantMax: modele.carburantMax,
-    scanner: structuredClone(modele.scanner),
+    scanner: structuredClone(modele.scanner || {}),
     ameliorations: structuredClone(modele.ameliorations || []),
+    ameliorationsMax: structuredClone(modele.ameliorationsMax || {}),
+  }
+}
+
+export function normaliserVaisseauPossede(vaisseau) {
+  if (!vaisseau) {
+    return null
+  }
+
+  const modele = donneesVaisseaux.find(
+    (modeleVaisseau) =>
+      modeleVaisseau.id === vaisseau.modeleId || modeleVaisseau.id === vaisseau.id,
+  )
+
+  if (!modele) {
+    return structuredClone(vaisseau)
+  }
+
+  const coqueMax = Number(vaisseau.coqueMax ?? modele.coqueMax ?? 0)
+  const souteMax = Number(vaisseau.souteMax ?? modele.souteMax ?? 0)
+  const carburantMax = Number(vaisseau.carburantMax ?? modele.carburantMax ?? 0)
+
+  return {
+    id: vaisseau.id || `${modele.id}_001`,
+    modeleId: vaisseau.modeleId || modele.id,
+    nom: vaisseau.nom || modele.nom,
+    constructeur: vaisseau.constructeur || modele.constructeur,
+    role: vaisseau.role || modele.role,
+    coque: bornerValeur(Number(vaisseau.coque ?? coqueMax), 0, coqueMax),
+    coqueMax,
+    soute: bornerValeur(Number(vaisseau.soute ?? 0), 0, souteMax),
+    souteMax,
+    puissanceMiniere: Number(vaisseau.puissanceMiniere ?? modele.puissanceMiniere ?? 0),
+    dronesMiniersMax: Number(vaisseau.dronesMiniersMax ?? modele.dronesMiniersMax ?? 0),
+    carburant: bornerValeur(Number(vaisseau.carburant ?? carburantMax), 0, carburantMax),
+    carburantMax,
+    scanner: structuredClone(vaisseau.scanner || modele.scanner || {}),
+    ameliorations: structuredClone(vaisseau.ameliorations || modele.ameliorations || []),
+    ameliorationsMax: structuredClone(vaisseau.ameliorationsMax || modele.ameliorationsMax || {}),
   }
 }
 
@@ -82,17 +125,40 @@ export function synchroniserFlotteDepuisVaisseauActif(etat = recupererEtatJeu())
     return
   }
 
-  vaisseauActif.coque = etat.vaisseau.coque
-  vaisseauActif.coqueMax = etat.vaisseau.coqueMax
-  vaisseauActif.soute = etat.vaisseau.soute
-  vaisseauActif.souteMax = etat.vaisseau.souteMax
-  vaisseauActif.puissanceMiniere = etat.vaisseau.puissanceMiniere
-  vaisseauActif.dronesMiniersMax = etat.vaisseau.dronesMiniersMax
-  vaisseauActif.carburantMax = etat.vaisseau.carburantMax
-  vaisseauActif.carburant = etat.ressources.carburant
+  vaisseauActif.coqueMax = Number(etat.vaisseau.coqueMax ?? vaisseauActif.coqueMax)
+  vaisseauActif.coque = bornerValeur(
+    Number(etat.vaisseau.coque ?? vaisseauActif.coque),
+    0,
+    vaisseauActif.coqueMax,
+  )
+
+  vaisseauActif.souteMax = Number(etat.vaisseau.souteMax ?? vaisseauActif.souteMax)
+  vaisseauActif.soute = bornerValeur(
+    Number(etat.vaisseau.soute ?? vaisseauActif.soute),
+    0,
+    vaisseauActif.souteMax,
+  )
+
+  vaisseauActif.puissanceMiniere = Number(
+    etat.vaisseau.puissanceMiniere ?? vaisseauActif.puissanceMiniere,
+  )
+  vaisseauActif.dronesMiniersMax = Number(
+    etat.vaisseau.dronesMiniersMax ?? vaisseauActif.dronesMiniersMax,
+  )
+
+  vaisseauActif.carburantMax = Number(etat.vaisseau.carburantMax ?? vaisseauActif.carburantMax)
+  vaisseauActif.carburant = bornerValeur(
+    Number(etat.ressources.carburant ?? vaisseauActif.carburant),
+    0,
+    vaisseauActif.carburantMax,
+  )
+
   vaisseauActif.scanner = structuredClone(etat.vaisseau.scanner || vaisseauActif.scanner || {})
   vaisseauActif.ameliorations = structuredClone(
     etat.vaisseau.ameliorations || vaisseauActif.ameliorations || [],
+  )
+  vaisseauActif.ameliorationsMax = structuredClone(
+    etat.vaisseau.ameliorationsMax || vaisseauActif.ameliorationsMax || {},
   )
 }
 
@@ -118,6 +184,7 @@ export function synchroniserVaisseauActifDansEtat(etat = recupererEtatJeu()) {
     carburantMax: vaisseauActif.carburantMax,
     scanner: structuredClone(vaisseauActif.scanner || {}),
     ameliorations: structuredClone(vaisseauActif.ameliorations || []),
+    ameliorationsMax: structuredClone(vaisseauActif.ameliorationsMax || {}),
   }
 
   etat.ressources.carburant = vaisseauActif.carburant
@@ -141,12 +208,25 @@ export function hydraterEtatVaisseauxApresChargement(etat = recupererEtatJeu()) 
     vaisseauHydrate.ameliorations = structuredClone(
       etat.vaisseau?.ameliorations || vaisseauHydrate.ameliorations,
     )
+    vaisseauHydrate.ameliorationsMax = structuredClone(
+      etat.vaisseau?.ameliorationsMax || vaisseauHydrate.ameliorationsMax || {},
+    )
 
-    etat.vaisseauxPossedes = [vaisseauHydrate]
-    etat.vaisseauActifId = vaisseauHydrate.id
+    etat.vaisseauxPossedes = [normaliserVaisseauPossede(vaisseauHydrate)]
+    etat.vaisseauActifId = etat.vaisseauxPossedes[0].id
+  } else {
+    etat.vaisseauxPossedes = etat.vaisseauxPossedes
+      .map((vaisseau) => normaliserVaisseauPossede(vaisseau))
+      .filter(Boolean)
   }
 
   if (!etat.vaisseauActifId && etat.vaisseauxPossedes.length > 0) {
+    etat.vaisseauActifId = etat.vaisseauxPossedes[0].id
+  }
+
+  const vaisseauActif = recupererVaisseauActif(etat)
+
+  if (!vaisseauActif && etat.vaisseauxPossedes.length > 0) {
     etat.vaisseauActifId = etat.vaisseauxPossedes[0].id
   }
 
@@ -283,7 +363,7 @@ export function acheterVaisseau(modeleId) {
   const nouveauVaisseau = creerInstanceVaisseauDepuisModele(modeleId, suffixe)
 
   etat.ressources.credits -= modele.prix
-  etat.vaisseauxPossedes.push(nouveauVaisseau)
+  etat.vaisseauxPossedes.push(normaliserVaisseauPossede(nouveauVaisseau))
 
   ajouterAuJournal(
     `Acquisition confirmée : ${modele.nom} ajouté au hangar pour ${modele.prix} cr.`,


### PR DESCRIPTION
## Objet
Faire de la coque une donnée réellement portée par chaque vaisseau possédé, et non plus seulement par le miroir du vaisseau actif.

## Contenu
- normalisation des vaisseaux possédés à l’hydratation
- conservation explicite des données individuelles de coque pour chaque châssis
- renforcement de la synchronisation entre :
  - flotte réelle (`vaisseauxPossedes`)
  - vaisseau actif
  - miroir `etat.vaisseau`
- sécurisation de la création des nouveaux vaisseaux achetés
- amélioration de la robustesse au chargement de sauvegardes anciennes ou partielles
- correction d’une régression atelier révélée par l’introduction des identifiants d’instance (`hw_mule_001`, etc.)
- correction de la recherche du modèle actif pour les améliorations via `modeleId`

## Résultat
- chaque vaisseau possède désormais sa propre intégrité de coque
- le changement de vaisseau ne transfère plus l’état de coque d’un appareil à un autre
- le miroir `etat.vaisseau` reste un reflet du seul vaisseau actif
- les améliorations d’atelier restent compatibles avec la gestion de flotte

## Tests effectués
- chargement de partie
- vérification de l’hydratation de la flotte
- achat d’améliorations sur le Mule
- achat du Caravel
- changement de vaisseau
- retour au vaisseau précédent
- vérification de la conservation des états individuels

## Notes
- pas encore de dégâts appliqués dans cette MR
- pas encore de restrictions métier liées à la coque
- cette MR prépare directement les tickets suivants de la v0.3.14 autour du risque, de la maintenance et de l’affichage de coque