### PR TITLE
v0.3.14-52 : feat(coque) : afficher l’état de coque dans le panneau vaisseau

### DIFF
--- a/src/assets/styles/features/ship.css
+++ b/src/assets/styles/features/ship.css
@@ -5,6 +5,7 @@
    - en-tête du panneau vaisseau
    - sous-titre constructeur / nom
    - badges de rôle
+   - état de coque
    - métriques du vaisseau
    ========================================================= */
 
@@ -85,10 +86,123 @@
   line-height: 1.3;
 }
 
+/* ===== État de coque ===== */
+
+.ship-panel-hull-status {
+  margin: 0 0 0.6rem;
+  padding: 0.45rem 0.55rem;
+  border: 1px solid rgba(125, 184, 255, 0.08);
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.ship-panel-hull-status--compact {
+  padding: 0.45rem 0.55rem;
+  margin-bottom: 0.6rem;
+}
+
+.ship-panel-hull-status-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.45rem;
+  margin-bottom: 0.25rem;
+}
+
+.ship-panel-hull-title {
+  font-size: 0.66rem;
+  color: rgba(210, 225, 245, 0.64);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.ship-hull-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.14rem 0.4rem;
+  border-radius: 999px;
+  font-size: 0.6rem;
+  font-weight: 700;
+  white-space: nowrap;
+  line-height: 1;
+  border: 1px solid transparent;
+}
+
+.ship-hull-badge--nominale {
+  color: #b9f0c9;
+  background: rgba(39, 122, 73, 0.18);
+  border-color: rgba(86, 196, 124, 0.28);
+}
+
+.ship-hull-badge--degradee {
+  color: #f5d7a1;
+  background: rgba(168, 104, 32, 0.18);
+  border-color: rgba(214, 146, 58, 0.28);
+}
+
+.ship-hull-badge--critique {
+  color: #ffb8b8;
+  background: rgba(150, 44, 44, 0.2);
+  border-color: rgba(224, 90, 90, 0.32);
+}
+
+.ship-hull-badge--hors-service {
+  color: #ffd5d5;
+  background: rgba(115, 18, 18, 0.28);
+  border-color: rgba(224, 90, 90, 0.42);
+}
+
+.ship-panel-hull-bar {
+  width: 100%;
+  height: 5px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.ship-panel-hull-bar-fill {
+  height: 100%;
+  border-radius: 999px;
+  transition: width 0.2s ease;
+}
+
+.ship-panel-hull-bar-fill.ship-hull-badge--nominale {
+  background: linear-gradient(90deg, rgba(86, 196, 124, 0.75) 0%, rgba(110, 220, 170, 0.95) 100%);
+}
+
+.ship-panel-hull-bar-fill.ship-hull-badge--degradee {
+  background: linear-gradient(90deg, rgba(214, 146, 58, 0.7) 0%, rgba(245, 215, 161, 0.95) 100%);
+}
+
+.ship-panel-hull-bar-fill.ship-hull-badge--critique {
+  background: linear-gradient(90deg, rgba(170, 60, 60, 0.7) 0%, rgba(255, 184, 184, 0.95) 100%);
+}
+
+.ship-panel-hull-bar-fill.ship-hull-badge--hors-service {
+  background: linear-gradient(90deg, rgba(90, 18, 18, 0.8) 0%, rgba(180, 70, 70, 0.95) 100%);
+}
+
+.ship-panel-hull-meta {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin: 0.22rem 0 0;
+  font-size: 0.7rem;
+  color: rgba(210, 225, 245, 0.76);
+}
+
+/* ===== Métriques ===== */
+
 .ship-panel-metrics {
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 0.35rem 0.9rem;
+}
+
+.ship-panel-metrics--three-cols {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.35rem 0.7rem;
 }
 
 .ship-panel-metrics p {
@@ -96,8 +210,8 @@
   display: flex;
   flex-direction: column;
   gap: 0.08rem;
-  font-size: 0.76rem;
-  line-height: 1.2;
+  font-size: 0.74rem;
+  line-height: 1.15;
 }
 
 .ship-panel-metrics p span {
@@ -106,6 +220,6 @@
 
 .ship-panel-metrics p strong {
   color: #f3f7ff;
-  font-size: 0.84rem;
+  font-size: 0.82rem;
   font-weight: 600;
 }

--- a/src/components/ShipPanel.vue
+++ b/src/components/ShipPanel.vue
@@ -1,88 +1,135 @@
 <script setup>
 import { computed } from 'vue'
+import { recupererEtatCoque } from '../game/systemeCoque'
 
 const props = defineProps({
-  vaisseau: {
-    type: Object,
-    required: true,
-  },
-  industrie: {
-    type: Object,
-    required: true,
-  },
+    vaisseau: {
+        type: Object,
+        required: true,
+    },
+    industrie: {
+        type: Object,
+        required: true,
+    },
 })
 
 const roleLabel = computed(() => {
-  if (props.vaisseau?.role === 'mineur_leger') return 'Mineur léger'
-  if (props.vaisseau?.role === 'mineur_lourd') return 'Mineur lourd'
-  if (props.vaisseau?.role === 'mineur_renforce') return 'Mineur renforcé'
-  if (props.vaisseau?.role === 'transporteur_marchand') return 'Transporteur marchand'
-  return 'Châssis polyvalent'
+    if (props.vaisseau?.role === 'mineur_leger') return 'Mineur léger'
+    if (props.vaisseau?.role === 'mineur_lourd') return 'Mineur lourd'
+    if (props.vaisseau?.role === 'mineur_renforce') return 'Mineur renforcé'
+    if (props.vaisseau?.role === 'transporteur_marchand') return 'Transporteur marchand'
+    return 'Châssis polyvalent'
 })
 
 const accrocheRole = computed(() => {
-  if (props.vaisseau?.role === 'transporteur_marchand') {
-    return 'Conçu pour le fret et les rotations commerciales.'
-  }
+    if (props.vaisseau?.role === 'transporteur_marchand') {
+        return 'Conçu pour le fret et les rotations commerciales.'
+    }
 
-  if (props.vaisseau?.role === 'mineur_lourd') {
-    return 'Pensé pour l’extraction soutenue et le rendement.'
-  }
+    if (props.vaisseau?.role === 'mineur_lourd') {
+        return 'Pensé pour l’extraction soutenue et le rendement.'
+    }
 
-  if (props.vaisseau?.role === 'mineur_renforce') {
-    return 'Prévu pour l’exploitation en zones plus exigeantes.'
-  }
+    if (props.vaisseau?.role === 'mineur_renforce') {
+        return 'Prévu pour l’exploitation en zones plus exigeantes.'
+    }
 
-  return 'Châssis utilitaire d’extraction légère.'
+    return 'Châssis utilitaire d’extraction légère.'
 })
 
 const badgeRoleClasse = computed(() => {
-  if (props.vaisseau?.role === 'transporteur_marchand')
-    return 'ship-role-badge ship-role-badge--trade'
-  if (props.vaisseau?.role === 'mineur_lourd') return 'ship-role-badge ship-role-badge--heavy'
-  if (props.vaisseau?.role === 'mineur_renforce')
-    return 'ship-role-badge ship-role-badge--reinforced'
-  return 'ship-role-badge ship-role-badge--light'
+    if (props.vaisseau?.role === 'transporteur_marchand') {
+        return 'ship-role-badge ship-role-badge--trade'
+    }
+
+    if (props.vaisseau?.role === 'mineur_lourd') {
+        return 'ship-role-badge ship-role-badge--heavy'
+    }
+
+    if (props.vaisseau?.role === 'mineur_renforce') {
+        return 'ship-role-badge ship-role-badge--reinforced'
+    }
+
+    return 'ship-role-badge ship-role-badge--light'
 })
+
+const infosCoque = computed(() =>
+    recupererEtatCoque(props.vaisseau?.coque ?? 0, props.vaisseau?.coqueMax ?? 0),
+)
+
+const badgeCoqueClasse = computed(() => {
+    if (infosCoque.value.code === 'hors_service') {
+        return 'ship-hull-badge ship-hull-badge--hors-service'
+    }
+
+    if (infosCoque.value.code === 'critique') {
+        return 'ship-hull-badge ship-hull-badge--critique'
+    }
+
+    if (infosCoque.value.code === 'degradee') {
+        return 'ship-hull-badge ship-hull-badge--degradee'
+    }
+
+    return 'ship-hull-badge ship-hull-badge--nominale'
+})
+
+const largeurBarreCoque = computed(() => `${infosCoque.value.pourcentage}%`)
 </script>
 
 <template>
-  <section class="panel">
-    <div class="ship-panel-header">
-      <div class="ship-panel-title-block">
-        <h2>⛭ Vaisseau</h2>
-        <p class="ship-panel-subtitle">
+    <section class="panel">
+        <div class="ship-panel-header">
+            <div class="ship-panel-title-block">
+                <h2>⛭ Vaisseau</h2>
+                <p class="ship-panel-subtitle">
           <span class="ship-panel-ship-group">
             <span class="ship-panel-ship-name">{{ vaisseau.nom }}</span>
             <span class="ship-panel-separator"> — </span>
           </span>
-          <span class="ship-panel-builder">{{ vaisseau.constructeur }}</span>
-        </p>
-      </div>
+                    <span class="ship-panel-builder">{{ vaisseau.constructeur }}</span>
+                </p>
+            </div>
 
-      <span :class="badgeRoleClasse">
+            <span :class="badgeRoleClasse">
         {{ roleLabel }}
       </span>
-    </div>
+        </div>
 
-    <p class="ship-panel-role-line">
-      {{ accrocheRole }}
-    </p>
+        <p class="ship-panel-role-line">
+            {{ accrocheRole }}
+        </p>
 
-    <div class="ship-panel-metrics">
-      <p>
-        <span>Coque</span><strong>{{ vaisseau.coque }} / {{ vaisseau.coqueMax }}</strong>
-      </p>
-      <p>
-        <span>Soute</span><strong>{{ vaisseau.soute }} / {{ vaisseau.souteMax }}</strong>
-      </p>
-      <p>
-        <span>Canon minier</span><strong>{{ vaisseau.puissanceMiniere }}</strong>
-      </p>
-      <p>
+        <div class="ship-panel-hull-status ship-panel-hull-status--compact">
+            <div class="ship-panel-hull-status-head">
+                <span class="ship-panel-hull-title">Intégrité de coque</span>
+                <span :class="badgeCoqueClasse">{{ infosCoque.label }}</span>
+            </div>
+
+            <div class="ship-panel-hull-bar">
+                <div
+                    class="ship-panel-hull-bar-fill"
+                    :class="badgeCoqueClasse"
+                    :style="{ width: largeurBarreCoque }"
+                ></div>
+            </div>
+
+            <p class="ship-panel-hull-meta">
+                <span>{{ vaisseau.coque }} / {{ vaisseau.coqueMax }}</span>
+                <span>{{ infosCoque.pourcentage }}%</span>
+            </p>
+        </div>
+
+        <div class="ship-panel-metrics ship-panel-metrics--three-cols">
+            <p>
+                <span>Soute</span><strong>{{ vaisseau.soute }} / {{ vaisseau.souteMax }}</strong>
+            </p>
+            <p>
+                <span>Canon minier</span><strong>{{ vaisseau.puissanceMiniere }}</strong>
+            </p>
+            <p>
         <span>Drones</span
         ><strong>{{ industrie.drones.length }} / {{ vaisseau.dronesMiniersMax }}</strong>
-      </p>
-    </div>
-  </section>
+            </p>
+        </div>
+    </section>
 </template>


### PR DESCRIPTION
## Objet
Afficher clairement l’état de coque du vaisseau actif dans l’interface, au sein du panneau Vaisseau.

## Contenu
- ajout d’un bloc dédié à l’intégrité de coque dans le `ShipPanel`
- affichage de la valeur actuelle et maximale de coque
- affichage du pourcentage d’intégrité
- affichage de l’état courant :
  - nominale
  - dégradée
  - critique
  - hors service
- ajout d’un badge visuel et d’une barre de progression de coque
- suppression du doublon d’affichage de la coque dans les métriques secondaires
- réorganisation des métriques restantes sur trois colonnes :
  - soute
  - canon minier
  - drones
- ajustements visuels pour compacter le bloc d’intégrité et mieux l’intégrer au panneau latéral

## Résultat
- l’état de coque devient immédiatement lisible pour le joueur
- le panneau Vaisseau gagne en clarté sans surcharge visuelle
- l’interface prépare directement les futurs tickets liés à :
  - la réparation
  - le coût de maintenance
  - les restrictions liées à l’état du châssis

## Tests effectués
- affichage de la coque nominale
- affichage du pourcentage d’intégrité
- vérification du changement d’état selon la valeur de coque
- vérification du rendu visuel compact dans le panneau latéral
- vérification de l’absence de doublon de la métrique coque

## Notes
- cette MR n’ajoute pas encore de réparation
- cette MR n’ajoute pas encore de restriction d’action liée à la coque
- elle prépare directement le ticket #54