### PR TITLE
v0.3.14-52 : feat(atelier) : ajouter la réparation complète du vaisseau en station

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -15,18 +15,19 @@ import HangarPanel from './components/HangarPanel.vue'
 import { recupererEtatJeu, reinitialiserEtatJeu } from './game/etatJeu'
 import { chargerJeu, sauvegarderJeu } from './game/systemeSauvegarde'
 import {
-  minerMineraiManuellement,
-  vendreTousLesMinerais,
-  acheterDroneMinier,
-  deployerDrones,
-  rappelerDrones,
+    minerMineraiManuellement,
+    vendreTousLesMinerais,
+    acheterDroneMinier,
+    deployerDrones,
+    rappelerDrones,
 } from './game/systemeMinage'
 import { acheterMineraiEnStation, vendreMineraiEnStation } from './game/systemeCommerce'
 import { ravitaillerCarburant } from './game/systemeRavitaillement'
 import { ameliorerVaisseau } from './game/systemeAmeliorations'
+import { reparerVaisseauActif } from './game/systemeReparation'
 import {
-  selectionnerDestination,
-  lancerVoyageVersDestinationSelectionnee,
+    selectionnerDestination,
+    lancerVoyageVersDestinationSelectionnee,
 } from './game/systemeNavigation'
 import { allerEnZoneOperations, retourALaStation } from './game/systemeLocalisation'
 import { scannerAmasMinier } from './game/systemeExploration'
@@ -37,205 +38,211 @@ import { acheterVaisseau, changerVaisseauActif } from './game/systemeVaisseaux'
 const etat = reactive({})
 
 function creerEtatUIInitial() {
-  return {
-    modeActif: 'station',
-    sousModeStation: 'commerce',
-  }
+    return {
+        modeActif: 'station',
+        sousModeStation: 'commerce',
+    }
 }
 
 const ui = reactive(creerEtatUIInitial())
 
 const secteurCourantComplet = computed(
-  () => donneesSecteurs.find((secteur) => secteur.id === etat.secteurCourant?.id) || null,
+    () => donneesSecteurs.find((secteur) => secteur.id === etat.secteurCourant?.id) || null,
 )
 
 const stationCourante = computed(() => secteurCourantComplet.value?.stationPrincipale ?? null)
 
 function normaliserSousModeStation() {
-  const services = stationCourante.value?.services
+    const services = stationCourante.value?.services
 
-  if (ui.sousModeStation === 'hangar') {
-    return
-  }
+    if (ui.sousModeStation === 'hangar') {
+        return
+    }
 
-  if (!services) {
+    if (!services) {
+        ui.sousModeStation = 'hangar'
+        return
+    }
+
+    if (ui.sousModeStation === 'commerce' && services.commerce) return
+    if (ui.sousModeStation === 'ravitaillement' && services.ravitaillement) return
+    if (ui.sousModeStation === 'atelier' && services.atelier) return
+
     ui.sousModeStation = 'hangar'
-    return
-  }
-
-  if (ui.sousModeStation === 'commerce' && services.commerce) return
-  if (ui.sousModeStation === 'ravitaillement' && services.ravitaillement) return
-  if (ui.sousModeStation === 'atelier' && services.atelier) return
-
-  ui.sousModeStation = 'hangar'
 }
 
 function synchroniserModeActifAvecPositionLocale() {
-  if (etat.positionLocale === 'station') {
-    ui.modeActif = 'station'
-    normaliserSousModeStation()
-    return
-  }
+    if (etat.positionLocale === 'station') {
+        ui.modeActif = 'station'
+        normaliserSousModeStation()
+        return
+    }
 
-  if (etat.positionLocale === 'operations') {
-    ui.modeActif = 'operations'
-  }
+    if (etat.positionLocale === 'operations') {
+        ui.modeActif = 'operations'
+    }
 }
 
 function synchroniserEtat() {
-  const etatCourant = structuredClone(recupererEtatJeu())
+    const etatCourant = structuredClone(recupererEtatJeu())
 
-  Object.keys(etat).forEach((cle) => {
-    delete etat[cle]
-  })
+    Object.keys(etat).forEach((cle) => {
+        delete etat[cle]
+    })
 
-  Object.assign(etat, etatCourant)
+    Object.assign(etat, etatCourant)
 
-  synchroniserModeActifAvecPositionLocale()
+    synchroniserModeActifAvecPositionLocale()
 }
 
 function gererMinageManuel() {
-  minerMineraiManuellement()
-  sauvegarderJeu()
-  synchroniserEtat()
+    minerMineraiManuellement()
+    sauvegarderJeu()
+    synchroniserEtat()
 }
 
 function gererScanner() {
-  scannerAmasMinier()
-  sauvegarderJeu()
-  synchroniserEtat()
+    scannerAmasMinier()
+    sauvegarderJeu()
+    synchroniserEtat()
 }
 
 function gererVenteMinerai() {
-  vendreTousLesMinerais()
-  sauvegarderJeu()
-  synchroniserEtat()
+    vendreTousLesMinerais()
+    sauvegarderJeu()
+    synchroniserEtat()
 }
 
 function gererVenteBien(idBien, quantite = 1) {
-  vendreMineraiEnStation(idBien, quantite)
-  sauvegarderJeu()
-  synchroniserEtat()
+    vendreMineraiEnStation(idBien, quantite)
+    sauvegarderJeu()
+    synchroniserEtat()
 }
 
 function gererAchatBien(idBien, quantite = 1) {
-  acheterMineraiEnStation(idBien, quantite)
-  sauvegarderJeu()
-  synchroniserEtat()
+    acheterMineraiEnStation(idBien, quantite)
+    sauvegarderJeu()
+    synchroniserEtat()
 }
 
 function gererAchatDrone() {
-  acheterDroneMinier()
-  sauvegarderJeu()
-  synchroniserEtat()
+    acheterDroneMinier()
+    sauvegarderJeu()
+    synchroniserEtat()
 }
 
 function gererDeploiementDrones() {
-  deployerDrones()
-  sauvegarderJeu()
-  synchroniserEtat()
+    deployerDrones()
+    sauvegarderJeu()
+    synchroniserEtat()
 }
 
 function gererRappelDrones() {
-  rappelerDrones()
-  sauvegarderJeu()
-  synchroniserEtat()
+    rappelerDrones()
+    sauvegarderJeu()
+    synchroniserEtat()
 }
 
 function gererRavitaillement() {
-  ravitaillerCarburant()
-  sauvegarderJeu()
-  synchroniserEtat()
+    ravitaillerCarburant()
+    sauvegarderJeu()
+    synchroniserEtat()
+}
+
+function gererReparationVaisseau() {
+    reparerVaisseauActif()
+    sauvegarderJeu()
+    synchroniserEtat()
 }
 
 function gererVoyage() {
-  lancerVoyageVersDestinationSelectionnee()
-  sauvegarderJeu()
-  synchroniserEtat()
+    lancerVoyageVersDestinationSelectionnee()
+    sauvegarderJeu()
+    synchroniserEtat()
 }
 
 function gererSelectionDestination(idDestination) {
-  selectionnerDestination(idDestination)
-  sauvegarderJeu()
-  synchroniserEtat()
+    selectionnerDestination(idDestination)
+    sauvegarderJeu()
+    synchroniserEtat()
 }
 
 function gererAmelioration(idAmelioration) {
-  ameliorerVaisseau(idAmelioration)
-  sauvegarderJeu()
-  synchroniserEtat()
+    ameliorerVaisseau(idAmelioration)
+    sauvegarderJeu()
+    synchroniserEtat()
 }
 
 function gererAllerOperations() {
-  const positionAvant = etat.positionLocale
+    const positionAvant = etat.positionLocale
 
-  allerEnZoneOperations()
-  sauvegarderJeu()
-  synchroniserEtat()
+    allerEnZoneOperations()
+    sauvegarderJeu()
+    synchroniserEtat()
 
-  if (positionAvant !== etat.positionLocale && etat.positionLocale === 'operations') {
-    ui.modeActif = 'operations'
-  }
+    if (positionAvant !== etat.positionLocale && etat.positionLocale === 'operations') {
+        ui.modeActif = 'operations'
+    }
 }
 
 function gererRetourStation() {
-  const positionAvant = etat.positionLocale
+    const positionAvant = etat.positionLocale
 
-  retourALaStation()
-  sauvegarderJeu()
-  synchroniserEtat()
+    retourALaStation()
+    sauvegarderJeu()
+    synchroniserEtat()
 
-  if (positionAvant !== etat.positionLocale && etat.positionLocale === 'station') {
-    ui.modeActif = 'station'
-    normaliserSousModeStation()
-  }
+    if (positionAvant !== etat.positionLocale && etat.positionLocale === 'station') {
+        ui.modeActif = 'station'
+        normaliserSousModeStation()
+    }
 }
 
 function gererChangerVaisseau(idVaisseau) {
-  changerVaisseauActif(idVaisseau)
-  sauvegarderJeu()
-  synchroniserEtat()
+    changerVaisseauActif(idVaisseau)
+    sauvegarderJeu()
+    synchroniserEtat()
 }
 
 function gererAcheterVaisseau(modeleId) {
-  acheterVaisseau(modeleId)
-  sauvegarderJeu()
-  synchroniserEtat()
+    acheterVaisseau(modeleId)
+    sauvegarderJeu()
+    synchroniserEtat()
 }
 
 function gererReinitialisation() {
-  reinitialiserEtatJeu()
-  Object.assign(ui, creerEtatUIInitial())
-  sauvegarderJeu()
-  synchroniserEtat()
+    reinitialiserEtatJeu()
+    Object.assign(ui, creerEtatUIInitial())
+    sauvegarderJeu()
+    synchroniserEtat()
 }
 
 function changerMode(mode) {
-  ui.modeActif = mode
-  if (mode === 'station') {
-    normaliserSousModeStation()
-  }
+    ui.modeActif = mode
+    if (mode === 'station') {
+        normaliserSousModeStation()
+    }
 }
 
 function changerSousModeStation(sousMode) {
-  ui.sousModeStation = sousMode
+    ui.sousModeStation = sousMode
 }
 
 onMounted(() => {
-  chargerJeu()
-  synchroniserEtat()
-  demarrerBoucleJeu(synchroniserEtat)
+    chargerJeu()
+    synchroniserEtat()
+    demarrerBoucleJeu(synchroniserEtat)
 })
 
 onUnmounted(() => {
-  arreterBoucleJeu()
+    arreterBoucleJeu()
 })
 </script>
 
 <template>
-  <main
-    class="app-shell"
-    v-if="
+    <main
+        class="app-shell"
+        v-if="
       etat.ressources &&
       etat.vaisseau &&
       etat.vaisseauxPossedes &&
@@ -248,126 +255,127 @@ onUnmounted(() => {
       etat.exploration &&
       etat.assistance
     "
-  >
-    <header class="app-header">
-      <div class="header-top">
-        <div class="header-brand">
-          <h1 class="title-line">
-            <span class="title-icon">✦</span>
-            <span>New Horizon</span>
-            <span class="title-icon">✦</span>
-          </h1>
+    >
+        <header class="app-header">
+            <div class="header-top">
+                <div class="header-brand">
+                    <h1 class="title-line">
+                        <span class="title-icon">✦</span>
+                        <span>New Horizon</span>
+                        <span class="title-icon">✦</span>
+                    </h1>
 
-          <p class="subtitle">
-            Simulation spatiale incrémentale de prospection minière et de commerce
-          </p>
+                    <p class="subtitle">
+                        Simulation spatiale incrémentale de prospection minière et de commerce
+                    </p>
 
-          <p class="meta-line">
-            v{{ etat.meta?.version }} — {{ etat.meta?.auteur }} — {{ etat.meta?.annee }}
-          </p>
+                    <p class="meta-line">
+                        v{{ etat.meta?.version }} — {{ etat.meta?.auteur }} — {{ etat.meta?.annee }}
+                    </p>
+                </div>
+
+                <HeaderActions
+                    :mode-actif="ui.modeActif"
+                    @changer-mode="changerMode"
+                    @reinitialiser="gererReinitialisation"
+                />
+            </div>
+        </header>
+
+        <div class="app-main">
+            <section class="main-column main-column-left">
+                <ResourcePanel
+                    :ressources="etat.ressources"
+                    :vaisseau="etat.vaisseau"
+                    :secteur-courant="etat.secteurCourant"
+                />
+                <ShipPanel :vaisseau="etat.vaisseau" :industrie="etat.industrie" />
+                <NavigationPanel
+                    :secteur-courant-id="etat.secteurCourant.id"
+                    :navigation="etat.navigation"
+                    :position-locale="etat.positionLocale"
+                    @selectionner-destination="gererSelectionDestination"
+                    @voyager="gererVoyage"
+                />
+            </section>
+
+            <section class="main-column main-column-center">
+                <div class="center-top">
+                    <OperationPanel
+                        v-if="ui.modeActif === 'operations'"
+                        :ressources="etat.ressources"
+                        :vaisseau="etat.vaisseau"
+                        :industrie="etat.industrie"
+                        :navigation="etat.navigation"
+                        :position-locale="etat.positionLocale"
+                        :exploration="etat.exploration"
+                        :assistance="etat.assistance"
+                        @miner="gererMinageManuel"
+                        @scanner="gererScanner"
+                        @aller-operations="gererAllerOperations"
+                        @retour-station="gererRetourStation"
+                        @deployer-drones="gererDeploiementDrones"
+                        @rappeler-drones="gererRappelDrones"
+                    />
+
+                    <StationServicesPanel
+                        v-else-if="ui.modeActif === 'station'"
+                        :secteur-courant="etat.secteurCourant"
+                        :vaisseau="etat.vaisseau"
+                        :ressources="etat.ressources"
+                        :sous-mode-station="ui.sousModeStation"
+                        :position-locale="etat.positionLocale"
+                        :economie="etat.economie"
+                        @changer-sous-mode-station="changerSousModeStation"
+                        @vendre="gererVenteMinerai"
+                        @vendre-bien="gererVenteBien"
+                        @acheter-bien="gererAchatBien"
+                        @ravitailler="gererRavitaillement"
+                        @acheter-drone="gererAchatDrone"
+                        @reparer-vaisseau="gererReparationVaisseau"
+                        @retour-station="gererRetourStation"
+                        @aller-operations="gererAllerOperations"
+                    >
+                        <template #hangar>
+                            <HangarPanel
+                                :secteur-courant="etat.secteurCourant"
+                                :vaisseau-actif-id="etat.vaisseauActifId"
+                                :vaisseaux-possedes="etat.vaisseauxPossedes"
+                                :vaisseau="etat.vaisseau"
+                                :ressources="etat.ressources"
+                                @changer-vaisseau="gererChangerVaisseau"
+                                @acheter-vaisseau="gererAcheterVaisseau"
+                            />
+                        </template>
+
+                        <template #atelier>
+                            <UpgradePanel
+                                :vaisseau="etat.vaisseau"
+                                :secteur-courant="etat.secteurCourant"
+                                @ameliorer="gererAmelioration"
+                            />
+                        </template>
+                    </StationServicesPanel>
+
+                    <NavigationPanel
+                        v-else-if="ui.modeActif === 'navigation'"
+                        :secteur-courant-id="etat.secteurCourant.id"
+                        :navigation="etat.navigation"
+                        :position-locale="etat.positionLocale"
+                        @selectionner-destination="gererSelectionDestination"
+                        @voyager="gererVoyage"
+                    />
+                </div>
+
+                <section class="journal-panel">
+                    <LogPanel :entrees="etat.journal" />
+                </section>
+            </section>
+
+            <aside class="right-aside">
+                <SectorPanel :secteur-courant="etat.secteurCourant" />
+                <StationPanel :secteur-courant="etat.secteurCourant" />
+            </aside>
         </div>
-
-        <HeaderActions
-          :mode-actif="ui.modeActif"
-          @changer-mode="changerMode"
-          @reinitialiser="gererReinitialisation"
-        />
-      </div>
-    </header>
-
-    <div class="app-main">
-      <section class="main-column main-column-left">
-        <ResourcePanel
-          :ressources="etat.ressources"
-          :vaisseau="etat.vaisseau"
-          :secteur-courant="etat.secteurCourant"
-        />
-        <ShipPanel :vaisseau="etat.vaisseau" :industrie="etat.industrie" />
-        <NavigationPanel
-          :secteur-courant-id="etat.secteurCourant.id"
-          :navigation="etat.navigation"
-          :position-locale="etat.positionLocale"
-          @selectionner-destination="gererSelectionDestination"
-          @voyager="gererVoyage"
-        />
-      </section>
-
-      <section class="main-column main-column-center">
-        <div class="center-top">
-          <OperationPanel
-            v-if="ui.modeActif === 'operations'"
-            :ressources="etat.ressources"
-            :vaisseau="etat.vaisseau"
-            :industrie="etat.industrie"
-            :navigation="etat.navigation"
-            :position-locale="etat.positionLocale"
-            :exploration="etat.exploration"
-            :assistance="etat.assistance"
-            @miner="gererMinageManuel"
-            @scanner="gererScanner"
-            @aller-operations="gererAllerOperations"
-            @retour-station="gererRetourStation"
-            @deployer-drones="gererDeploiementDrones"
-            @rappeler-drones="gererRappelDrones"
-          />
-
-          <StationServicesPanel
-            v-else-if="ui.modeActif === 'station'"
-            :secteur-courant="etat.secteurCourant"
-            :vaisseau="etat.vaisseau"
-            :ressources="etat.ressources"
-            :sous-mode-station="ui.sousModeStation"
-            :position-locale="etat.positionLocale"
-            :economie="etat.economie"
-            @changer-sous-mode-station="changerSousModeStation"
-            @vendre="gererVenteMinerai"
-            @vendre-bien="gererVenteBien"
-            @acheter-bien="gererAchatBien"
-            @ravitailler="gererRavitaillement"
-            @acheter-drone="gererAchatDrone"
-            @retour-station="gererRetourStation"
-            @aller-operations="gererAllerOperations"
-          >
-            <template #hangar>
-              <HangarPanel
-                :secteur-courant="etat.secteurCourant"
-                :vaisseau-actif-id="etat.vaisseauActifId"
-                :vaisseaux-possedes="etat.vaisseauxPossedes"
-                :vaisseau="etat.vaisseau"
-                :ressources="etat.ressources"
-                @changer-vaisseau="gererChangerVaisseau"
-                @acheter-vaisseau="gererAcheterVaisseau"
-              />
-            </template>
-
-            <template #atelier>
-              <UpgradePanel
-                :vaisseau="etat.vaisseau"
-                :secteur-courant="etat.secteurCourant"
-                @ameliorer="gererAmelioration"
-              />
-            </template>
-          </StationServicesPanel>
-
-          <NavigationPanel
-            v-else-if="ui.modeActif === 'navigation'"
-            :secteur-courant-id="etat.secteurCourant.id"
-            :navigation="etat.navigation"
-            :position-locale="etat.positionLocale"
-            @selectionner-destination="gererSelectionDestination"
-            @voyager="gererVoyage"
-          />
-        </div>
-
-        <section class="journal-panel">
-          <LogPanel :entrees="etat.journal" />
-        </section>
-      </section>
-
-      <aside class="right-aside">
-        <SectorPanel :secteur-courant="etat.secteurCourant" />
-        <StationPanel :secteur-courant="etat.secteurCourant" />
-      </aside>
-    </div>
-  </main>
+    </main>
 </template>

--- a/src/components/StationServicesPanel.vue
+++ b/src/components/StationServicesPanel.vue
@@ -2,52 +2,57 @@
 import { computed } from 'vue'
 import { donneesSecteurs } from '../game/dataSecteurs'
 import {
-  calculerCoursLocauxPourStation,
-  calculerTauxTaxePourSecurite,
-  construireResumeMarcheStation,
-  formaterPourcentageTaxe,
+    calculerCoursLocauxPourStation,
+    calculerTauxTaxePourSecurite,
+    construireResumeMarcheStation,
+    formaterPourcentageTaxe,
 } from '../game/systemeCommerce'
+import {
+    calculerCoutReparationVaisseau,
+    calculerPointsCoqueManquants,
+} from '../game/systemeReparation'
 
 const props = defineProps({
-  secteurCourant: {
-    type: Object,
-    required: true,
-  },
-  vaisseau: {
-    type: Object,
-    required: true,
-  },
-  ressources: {
-    type: Object,
-    required: true,
-  },
-  sousModeStation: {
-    type: String,
-    required: true,
-  },
-  positionLocale: {
-    type: String,
-    required: true,
-  },
-  economie: {
-    type: Object,
-    required: true,
-  },
+    secteurCourant: {
+        type: Object,
+        required: true,
+    },
+    vaisseau: {
+        type: Object,
+        required: true,
+    },
+    ressources: {
+        type: Object,
+        required: true,
+    },
+    sousModeStation: {
+        type: String,
+        required: true,
+    },
+    positionLocale: {
+        type: String,
+        required: true,
+    },
+    economie: {
+        type: Object,
+        required: true,
+    },
 })
 
 const emit = defineEmits([
-  'changer-sous-mode-station',
-  'vendre',
-  'vendre-bien',
-  'acheter-bien',
-  'ravitailler',
-  'acheter-drone',
-  'aller-operations',
-  'retour-station',
+    'changer-sous-mode-station',
+    'vendre',
+    'vendre-bien',
+    'acheter-bien',
+    'ravitailler',
+    'acheter-drone',
+    'reparer-vaisseau',
+    'aller-operations',
+    'retour-station',
 ])
 
 const secteur = computed(() =>
-  donneesSecteurs.find((entree) => entree.id === props.secteurCourant.id),
+    donneesSecteurs.find((entree) => entree.id === props.secteurCourant.id),
 )
 
 const station = computed(() => secteur.value?.stationPrincipale ?? null)
@@ -57,7 +62,7 @@ const carburantManquant = computed(() => props.vaisseau.carburantMax - props.res
 const coutCarburantUnitaire = computed(() => station.value?.economie?.coutCarburantParUnite ?? 1)
 
 const coutRavitaillementComplet = computed(() => {
-  return Math.max(0, carburantManquant.value) * coutCarburantUnitaire.value
+    return Math.max(0, carburantManquant.value) * coutCarburantUnitaire.value
 })
 
 const tauxTaxe = computed(() => calculerTauxTaxePourSecurite(secteur.value?.securite ?? 1))
@@ -65,7 +70,7 @@ const tauxTaxe = computed(() => calculerTauxTaxePourSecurite(secteur.value?.secu
 const taxeLocalePourcent = computed(() => formaterPourcentageTaxe(tauxTaxe.value))
 
 const coursLocaux = computed(() =>
-  calculerCoursLocauxPourStation(station.value, props.ressources.minerais || {}),
+    calculerCoursLocauxPourStation(station.value, props.ressources.minerais || {}),
 )
 
 const resumeMarche = computed(() => construireResumeMarcheStation(station.value))
@@ -73,223 +78,233 @@ const resumeMarche = computed(() => construireResumeMarcheStation(station.value)
 const souteRestante = computed(() => props.vaisseau.souteMax - props.vaisseau.soute)
 
 const profilMarcheLabel = computed(() => {
-  const typeStation = station.value?.type || ''
+    const typeStation = station.value?.type || ''
 
-  if (typeStation.includes('commerciale')) return 'Hub commercial généraliste'
-  if (typeStation.includes('industrielle')) return 'Marché industriel de transit'
-  if (typeStation.includes('chantier')) return 'Débouché métallurgique et logistique'
-  if (typeStation.includes('mouillage')) return 'Marché frontalier brut'
-  if (typeStation.includes('port_franc')) return 'Port spéculatif périphérique'
-  if (typeStation.includes('terminal')) return 'Point d’appui avancé'
-  return 'Marché local'
+    if (typeStation.includes('commerciale')) return 'Hub commercial généraliste'
+    if (typeStation.includes('industrielle')) return 'Marché industriel de transit'
+    if (typeStation.includes('chantier')) return 'Débouché métallurgique et logistique'
+    if (typeStation.includes('mouillage')) return 'Marché frontalier brut'
+    if (typeStation.includes('port_franc')) return 'Port spéculatif périphérique'
+    if (typeStation.includes('terminal')) return 'Point d’appui avancé'
+    return 'Marché local'
 })
 
 const coutDroneMinier = computed(() => props.economie?.coutDroneMinier ?? 400)
 
+const pointsCoqueManquants = computed(() => calculerPointsCoqueManquants(props.vaisseau))
+
+const coutReparation = computed(() => calculerCoutReparationVaisseau(props.vaisseau))
+
+const reparationNecessaire = computed(() => pointsCoqueManquants.value > 0)
+
+const reparationAbordable = computed(
+    () => reparationNecessaire.value && (props.ressources?.credits || 0) >= coutReparation.value,
+)
+
 function recupererQuantiteEnSoute(idMinerai) {
-  return props.ressources?.minerais?.[idMinerai] || 0
+    return props.ressources?.minerais?.[idMinerai] || 0
 }
 
 function calculerQuantiteMaxAchetable(minerai) {
-  const prixUnitaire = minerai?.prixBrut || 0
+    const prixUnitaire = minerai?.prixBrut || 0
 
-  if (prixUnitaire <= 0) {
-    return 0
-  }
+    if (prixUnitaire <= 0) {
+        return 0
+    }
 
-  const quantiteParCredits = Math.floor((props.ressources.credits || 0) / prixUnitaire)
-  return Math.max(0, Math.min(souteRestante.value, quantiteParCredits))
+    const quantiteParCredits = Math.floor((props.ressources.credits || 0) / prixUnitaire)
+    return Math.max(0, Math.min(souteRestante.value, quantiteParCredits))
 }
 
 function acheterUnMinerai(idMinerai) {
-  emit('acheter-bien', idMinerai, 1)
+    emit('acheter-bien', idMinerai, 1)
 }
 
 function acheterMineraiMax(minerai) {
-  const quantiteMax = calculerQuantiteMaxAchetable(minerai)
+    const quantiteMax = calculerQuantiteMaxAchetable(minerai)
 
-  if (quantiteMax > 0) {
-    emit('acheter-bien', minerai.id, quantiteMax)
-  }
+    if (quantiteMax > 0) {
+        emit('acheter-bien', minerai.id, quantiteMax)
+    }
 }
 
 function vendreUnMinerai(idMinerai) {
-  emit('vendre-bien', idMinerai, 1)
+    emit('vendre-bien', idMinerai, 1)
 }
 
 function vendreMineraiMax(minerai) {
-  const quantiteMax = recupererQuantiteEnSoute(minerai.id)
+    const quantiteMax = recupererQuantiteEnSoute(minerai.id)
 
-  if (quantiteMax > 0) {
-    emit('vendre-bien', minerai.id, quantiteMax)
-  }
+    if (quantiteMax > 0) {
+        emit('vendre-bien', minerai.id, quantiteMax)
+    }
 }
 </script>
 
 <template>
-  <section class="panel station-services-panel" v-if="station">
-    <div class="station-services-header">
-      <h2>⌘ Services de station</h2>
-      <p class="station-services-subtitle">{{ station.nom }} — {{ station.type }}</p>
-    </div>
-
-    <div class="station-mode-tabs station-mode-tabs--with-launch">
-      <button
-        v-if="positionLocale === 'station'"
-        class="station-launch-button action-button-with-icon"
-        @click="emit('aller-operations')"
-      >
-        <span class="button-icon" aria-hidden="true">⌘</span>
-        <span>Zone d’opérations</span>
-      </button>
-
-      <button
-        :class="{ 'is-active': sousModeStation === 'hangar' }"
-        class="action-button-with-icon"
-        @click="emit('changer-sous-mode-station', 'hangar')"
-      >
-        <span class="button-icon" aria-hidden="true">⌂</span>
-        <span>Hangar</span>
-      </button>
-
-      <button
-        v-if="station.services.commerce"
-        :class="{ 'is-active': sousModeStation === 'commerce' }"
-        class="action-button-with-icon"
-        @click="emit('changer-sous-mode-station', 'commerce')"
-      >
-        <span class="button-icon" aria-hidden="true">✦</span>
-        <span>Commerce</span>
-      </button>
-
-      <button
-        v-if="station.services.ravitaillement"
-        :class="{ 'is-active': sousModeStation === 'ravitaillement' }"
-        class="action-button-with-icon"
-        @click="emit('changer-sous-mode-station', 'ravitaillement')"
-      >
-        <span class="button-icon" aria-hidden="true">⛽</span>
-        <span>Ravitaillement</span>
-      </button>
-
-      <button
-        v-if="station.services.atelier"
-        :class="{ 'is-active': sousModeStation === 'atelier' }"
-        class="action-button-with-icon"
-        @click="emit('changer-sous-mode-station', 'atelier')"
-      >
-        <span class="button-icon" aria-hidden="true">⚙</span>
-        <span>Atelier</span>
-      </button>
-    </div>
-
-    <template v-if="positionLocale !== 'station'">
-      <div class="station-service-card station-service-card-commerce">
-        <div class="station-service-card-header">
-          <h3>Accès indisponible</h3>
-          <span class="station-service-badge">Hors station</span>
+    <section class="panel station-services-panel" v-if="station">
+        <div class="station-services-header">
+            <h2>⌘ Services de station</h2>
+            <p class="station-services-subtitle">{{ station.nom }} — {{ station.type }}</p>
         </div>
 
-        <p class="station-service-description">
-          Les services de station ne sont accessibles qu’une fois revenu et amarré à la station
-          locale.
-        </p>
+        <div class="station-mode-tabs station-mode-tabs--with-launch">
+            <button
+                v-if="positionLocale === 'station'"
+                class="station-launch-button action-button-with-icon"
+                @click="emit('aller-operations')"
+            >
+                <span class="button-icon" aria-hidden="true">⌘</span>
+                <span>Zone d’opérations</span>
+            </button>
 
-        <div class="action-group">
-          <button class="action-button-with-icon" @click="emit('retour-station')">
-            <span class="button-icon" aria-hidden="true">⌂</span>
-            <span>Retourner à la station</span>
-          </button>
-        </div>
-      </div>
-    </template>
+            <button
+                :class="{ 'is-active': sousModeStation === 'hangar' }"
+                class="action-button-with-icon"
+                @click="emit('changer-sous-mode-station', 'hangar')"
+            >
+                <span class="button-icon" aria-hidden="true">⌂</span>
+                <span>Hangar</span>
+            </button>
 
-    <template v-else>
-      <div v-if="sousModeStation === 'hangar'" class="station-service-mode-hangar-scroll">
-        <slot name="hangar" />
-      </div>
+            <button
+                v-if="station.services.commerce"
+                :class="{ 'is-active': sousModeStation === 'commerce' }"
+                class="action-button-with-icon"
+                @click="emit('changer-sous-mode-station', 'commerce')"
+            >
+                <span class="button-icon" aria-hidden="true">✦</span>
+                <span>Commerce</span>
+            </button>
 
-      <div
-        v-else-if="sousModeStation === 'commerce'"
-        class="station-service-card station-service-card-commerce station-service-card--scrollable"
-      >
-        <div class="station-service-card-header">
-          <h3>¤ Commerce local</h3>
-          <span class="station-service-badge">Actif</span>
-        </div>
+            <button
+                v-if="station.services.ravitaillement"
+                :class="{ 'is-active': sousModeStation === 'ravitaillement' }"
+                class="action-button-with-icon"
+                @click="emit('changer-sous-mode-station', 'ravitaillement')"
+            >
+                <span class="button-icon" aria-hidden="true">⛽</span>
+                <span>Ravitaillement</span>
+            </button>
 
-        <div class="station-service-grid">
-          <div class="station-service-metric">
-            <span class="station-service-label">Service commercial</span>
-            <strong>Disponible</strong>
-          </div>
-
-          <div class="station-service-metric">
-            <span class="station-service-label">Taxe locale</span>
-            <strong>{{ taxeLocalePourcent }}</strong>
-          </div>
-
-          <div class="station-service-metric">
-            <span class="station-service-label">Soute</span>
-            <strong>{{ vaisseau.soute }} / {{ vaisseau.souteMax }}</strong>
-          </div>
-
-          <div class="station-service-metric">
-            <span class="station-service-label">Capacité restante</span>
-            <strong>{{ souteRestante }}</strong>
-          </div>
-
-          <div class="station-service-metric station-service-metric--full">
-            <span class="station-service-label">Profil de marché</span>
-            <strong>{{ profilMarcheLabel }}</strong>
-          </div>
+            <button
+                v-if="station.services.atelier"
+                :class="{ 'is-active': sousModeStation === 'atelier' }"
+                class="action-button-with-icon"
+                @click="emit('changer-sous-mode-station', 'atelier')"
+            >
+                <span class="button-icon" aria-hidden="true">⚙</span>
+                <span>Atelier</span>
+            </button>
         </div>
 
-        <p class="station-service-description">
-          Les achats et ventes utilisent la même soute embarquée. Les cours ci-dessous représentent
-          les prix locaux bruts par unité. La taxe locale s’applique lors des ventes, sur le montant
-          brut total de la transaction.
-        </p>
+        <template v-if="positionLocale !== 'station'">
+            <div class="station-service-card station-service-card-commerce">
+                <div class="station-service-card-header">
+                    <h3>Accès indisponible</h3>
+                    <span class="station-service-badge">Hors station</span>
+                </div>
 
-        <div class="station-market-insights station-market-insights--compact">
-          <div class="station-market-insight-card">
-            <h4>Meilleures ventes locales</h4>
-            <ul v-if="resumeMarche.haussiers.length > 0" class="station-market-list">
-              <li v-for="minerai in resumeMarche.haussiers" :key="minerai.id">
-                <span>{{ minerai.nom }}</span>
-                <strong>{{ minerai.variationPourcentageLabel }}</strong>
-              </li>
-            </ul>
-            <p v-else class="panel-note">Aucune prime locale notable.</p>
-          </div>
+                <p class="station-service-description">
+                    Les services de station ne sont accessibles qu’une fois revenu et amarré à la station
+                    locale.
+                </p>
 
-          <div class="station-market-insight-card">
-            <h4>Moins favorisées</h4>
-            <ul v-if="resumeMarche.baissiers.length > 0" class="station-market-list">
-              <li v-for="minerai in resumeMarche.baissiers" :key="minerai.id">
-                <span>{{ minerai.nom }}</span>
-                <strong>{{ minerai.variationPourcentageLabel }}</strong>
-              </li>
-            </ul>
-            <p v-else class="panel-note">Aucune décote locale notable.</p>
-          </div>
-        </div>
+                <div class="action-group">
+                    <button class="action-button-with-icon" @click="emit('retour-station')">
+                        <span class="button-icon" aria-hidden="true">⌂</span>
+                        <span>Retourner à la station</span>
+                    </button>
+                </div>
+            </div>
+        </template>
 
-        <div class="market-rate-grid market-rate-grid-three-cols">
-          <div v-for="minerai in coursLocaux" :key="minerai.id" class="market-rate-item">
-            <div class="market-rate-row market-rate-row--top">
+        <template v-else>
+            <div v-if="sousModeStation === 'hangar'" class="station-service-mode-hangar-scroll">
+                <slot name="hangar" />
+            </div>
+
+            <div
+                v-else-if="sousModeStation === 'commerce'"
+                class="station-service-card station-service-card-commerce station-service-card--scrollable"
+            >
+                <div class="station-service-card-header">
+                    <h3>¤ Commerce local</h3>
+                    <span class="station-service-badge">Actif</span>
+                </div>
+
+                <div class="station-service-grid">
+                    <div class="station-service-metric">
+                        <span class="station-service-label">Service commercial</span>
+                        <strong>Disponible</strong>
+                    </div>
+
+                    <div class="station-service-metric">
+                        <span class="station-service-label">Taxe locale</span>
+                        <strong>{{ taxeLocalePourcent }}</strong>
+                    </div>
+
+                    <div class="station-service-metric">
+                        <span class="station-service-label">Soute</span>
+                        <strong>{{ vaisseau.soute }} / {{ vaisseau.souteMax }}</strong>
+                    </div>
+
+                    <div class="station-service-metric">
+                        <span class="station-service-label">Capacité restante</span>
+                        <strong>{{ souteRestante }}</strong>
+                    </div>
+
+                    <div class="station-service-metric station-service-metric--full">
+                        <span class="station-service-label">Profil de marché</span>
+                        <strong>{{ profilMarcheLabel }}</strong>
+                    </div>
+                </div>
+
+                <p class="station-service-description">
+                    Les achats et ventes utilisent la même soute embarquée. Les cours ci-dessous représentent
+                    les prix locaux bruts par unité. La taxe locale s’applique lors des ventes, sur le montant
+                    brut total de la transaction.
+                </p>
+
+                <div class="station-market-insights station-market-insights--compact">
+                    <div class="station-market-insight-card">
+                        <h4>Meilleures ventes locales</h4>
+                        <ul v-if="resumeMarche.haussiers.length > 0" class="station-market-list">
+                            <li v-for="minerai in resumeMarche.haussiers" :key="minerai.id">
+                                <span>{{ minerai.nom }}</span>
+                                <strong>{{ minerai.variationPourcentageLabel }}</strong>
+                            </li>
+                        </ul>
+                        <p v-else class="panel-note">Aucune prime locale notable.</p>
+                    </div>
+
+                    <div class="station-market-insight-card">
+                        <h4>Moins favorisées</h4>
+                        <ul v-if="resumeMarche.baissiers.length > 0" class="station-market-list">
+                            <li v-for="minerai in resumeMarche.baissiers" :key="minerai.id">
+                                <span>{{ minerai.nom }}</span>
+                                <strong>{{ minerai.variationPourcentageLabel }}</strong>
+                            </li>
+                        </ul>
+                        <p v-else class="panel-note">Aucune décote locale notable.</p>
+                    </div>
+                </div>
+
+                <div class="market-rate-grid market-rate-grid-three-cols">
+                    <div v-for="minerai in coursLocaux" :key="minerai.id" class="market-rate-item">
+                        <div class="market-rate-row market-rate-row--top">
               <span class="market-rate-name">
                 <span class="resource-icon">{{ minerai.icone }}</span>
                 {{ minerai.abreviation }}
               </span>
 
-              <span class="market-rate-values">{{ minerai.prixBrut }} cr</span>
-            </div>
+                            <span class="market-rate-values">{{ minerai.prixBrut }} cr</span>
+                        </div>
 
-            <div class="market-rate-row market-rate-row--bottom">
+                        <div class="market-rate-row market-rate-row--bottom">
               <span
-                class="market-rate-variation"
-                :class="{
+                  class="market-rate-variation"
+                  :class="{
                   'market-rate-variation-up': minerai.variation === 'hausse',
                   'market-rate-variation-down': minerai.variation === 'baisse',
                   'market-rate-variation-stable': minerai.variation === 'stable',
@@ -298,146 +313,177 @@ function vendreMineraiMax(minerai) {
                 {{ minerai.variationSymbole }} {{ minerai.variationPourcentageLabel }}
               </span>
 
-              <span class="market-rate-average">moy. {{ minerai.prixMoyen }} cr</span>
-            </div>
+                            <span class="market-rate-average">moy. {{ minerai.prixMoyen }} cr</span>
+                        </div>
 
-            <div class="market-rate-row market-rate-row--bottom">
+                        <div class="market-rate-row market-rate-row--bottom">
               <span class="market-rate-average">
                 En soute : {{ recupererQuantiteEnSoute(minerai.id) }}
               </span>
+                        </div>
+
+                        <div class="action-group-market">
+                            <button
+                                class="market-rate-buy-button"
+                                :disabled="souteRestante <= 0 || ressources.credits < minerai.prixBrut"
+                                @click="acheterUnMinerai(minerai.id)"
+                            >
+                                +1
+                            </button>
+
+                            <button
+                                class="market-rate-buy-button"
+                                :disabled="calculerQuantiteMaxAchetable(minerai) <= 0"
+                                @click="acheterMineraiMax(minerai)"
+                            >
+                                +Max
+                            </button>
+
+                            <button
+                                class="market-rate-buy-button"
+                                :disabled="recupererQuantiteEnSoute(minerai.id) <= 0"
+                                @click="vendreUnMinerai(minerai.id)"
+                            >
+                                -1
+                            </button>
+
+                            <button
+                                class="market-rate-buy-button"
+                                :disabled="recupererQuantiteEnSoute(minerai.id) <= 0"
+                                @click="vendreMineraiMax(minerai)"
+                            >
+                                -Max
+                            </button>
+                        </div>
+                    </div>
+                </div>
+
+                <p class="market-rate-legend">
+                    Affichage : cours local brut par unité, comparé au cours moyen galactique.
+                </p>
+
+                <div class="action-group">
+                    <button class="action-button-with-icon" @click="emit('vendre')">
+                        <span class="button-icon" aria-hidden="true">✦</span>
+                        <span>Vendre le contenu minéral de la soute</span>
+                    </button>
+                </div>
             </div>
 
-            <div class="action-group-market">
-              <button
-                class="market-rate-buy-button"
-                :disabled="souteRestante <= 0 || ressources.credits < minerai.prixBrut"
-                @click="acheterUnMinerai(minerai.id)"
-              >
-                +1
-              </button>
+            <div
+                v-else-if="sousModeStation === 'ravitaillement'"
+                class="station-service-card station-service-card-fuel"
+            >
+                <div class="station-service-card-header">
+                    <h3>⛽ Ravitaillement</h3>
+                    <span class="station-service-badge">Actif</span>
+                </div>
 
-              <button
-                class="market-rate-buy-button"
-                :disabled="calculerQuantiteMaxAchetable(minerai) <= 0"
-                @click="acheterMineraiMax(minerai)"
-              >
-                +Max
-              </button>
+                <div class="station-service-grid">
+                    <div class="station-service-metric">
+                        <span class="station-service-label">Carburant actuel</span>
+                        <strong>{{ ressources.carburant }} / {{ vaisseau.carburantMax }}</strong>
+                    </div>
 
-              <button
-                class="market-rate-buy-button"
-                :disabled="recupererQuantiteEnSoute(minerai.id) <= 0"
-                @click="vendreUnMinerai(minerai.id)"
-              >
-                -1
-              </button>
+                    <div class="station-service-metric">
+                        <span class="station-service-label">Carburant manquant</span>
+                        <strong>{{ carburantManquant }}</strong>
+                    </div>
 
-              <button
-                class="market-rate-buy-button"
-                :disabled="recupererQuantiteEnSoute(minerai.id) <= 0"
-                @click="vendreMineraiMax(minerai)"
-              >
-                -Max
-              </button>
+                    <div class="station-service-metric">
+                        <span class="station-service-label">Prix unitaire</span>
+                        <strong>{{ coutCarburantUnitaire }} cr. / unité</strong>
+                    </div>
+
+                    <div class="station-service-metric">
+                        <span class="station-service-label">Coût du plein</span>
+                        <strong>{{ coutRavitaillementComplet }} cr.</strong>
+                    </div>
+                </div>
+
+                <p class="station-service-description">
+                    Recharge du réservoir principal au tarif local de la station.
+                </p>
+
+                <div class="action-group">
+                    <button class="action-button-with-icon" @click="emit('ravitailler')">
+                        <span class="button-icon" aria-hidden="true">⛽</span>
+                        <span>Ravitailler le vaisseau</span>
+                    </button>
+                </div>
             </div>
-          </div>
-        </div>
 
-        <p class="market-rate-legend">
-          Affichage : cours local brut par unité, comparé au cours moyen galactique.
-        </p>
+            <div
+                v-else-if="sousModeStation === 'atelier'"
+                class="station-service-card station-service-card-workshop"
+            >
+                <div class="station-service-card-header">
+                    <h3>⚙ Atelier technique</h3>
+                    <span class="station-service-badge">Actif</span>
+                </div>
 
-        <div class="action-group">
-          <button class="action-button-with-icon" @click="emit('vendre')">
-            <span class="button-icon" aria-hidden="true">✦</span>
-            <span>Vendre le contenu minéral de la soute</span>
-          </button>
-        </div>
-      </div>
+                <div class="station-service-grid">
+                    <div class="station-service-metric">
+                        <span class="station-service-label">Service atelier</span>
+                        <strong>Disponible</strong>
+                    </div>
 
-      <div
-        v-else-if="sousModeStation === 'ravitaillement'"
-        class="station-service-card station-service-card-fuel"
-      >
-        <div class="station-service-card-header">
-          <h3>⛽ Ravitaillement</h3>
-          <span class="station-service-badge">Actif</span>
-        </div>
+                    <div class="station-service-metric">
+                        <span class="station-service-label">Capacité</span>
+                        <strong>Maintenance légère</strong>
+                    </div>
 
-        <div class="station-service-grid">
-          <div class="station-service-metric">
-            <span class="station-service-label">Carburant actuel</span>
-            <strong>{{ ressources.carburant }} / {{ vaisseau.carburantMax }}</strong>
-          </div>
+                    <div class="station-service-metric">
+                        <span class="station-service-label">Coque actuelle</span>
+                        <strong>{{ vaisseau.coque }} / {{ vaisseau.coqueMax }}</strong>
+                    </div>
 
-          <div class="station-service-metric">
-            <span class="station-service-label">Carburant manquant</span>
-            <strong>{{ carburantManquant }}</strong>
-          </div>
+                    <div class="station-service-metric">
+                        <span class="station-service-label">Réparation complète</span>
+                        <strong v-if="reparationNecessaire">{{ coutReparation }} crédits</strong>
+                        <strong v-else>Aucune nécessaire</strong>
+                    </div>
+                </div>
 
-          <div class="station-service-metric">
-            <span class="station-service-label">Prix unitaire</span>
-            <strong>{{ coutCarburantUnitaire }} cr. / unité</strong>
-          </div>
+                <p class="station-service-description">
+                    Accès aux réparations de coque, aux améliorations du vaisseau et à l’acquisition de drones
+                    miniers.
+                </p>
 
-          <div class="station-service-metric">
-            <span class="station-service-label">Coût du plein</span>
-            <strong>{{ coutRavitaillementComplet }} cr.</strong>
-          </div>
-        </div>
+                <div class="action-group">
+                    <button
+                        class="action-button-with-icon"
+                        :disabled="!reparationNecessaire || !reparationAbordable"
+                        @click="emit('reparer-vaisseau')"
+                    >
+                        <span class="button-icon" aria-hidden="true">🛠</span>
+                        <span>Réparer complètement le vaisseau</span>
+                    </button>
+                </div>
 
-        <p class="station-service-description">
-          Recharge du réservoir principal au tarif local de la station.
-        </p>
+                <p v-if="!reparationNecessaire" class="panel-note">
+                    La coque du vaisseau actif est déjà à son niveau maximal.
+                </p>
 
-        <div class="action-group">
-          <button class="action-button-with-icon" @click="emit('ravitailler')">
-            <span class="button-icon" aria-hidden="true">⛽</span>
-            <span>Ravitailler le vaisseau</span>
-          </button>
-        </div>
-      </div>
+                <p v-else-if="!reparationAbordable" class="panel-note panel-note-warning">
+                    Crédits insuffisants pour financer une réparation complète de la coque.
+                </p>
 
-      <div
-        v-else-if="sousModeStation === 'atelier'"
-        class="station-service-card station-service-card-workshop"
-      >
-        <div class="station-service-card-header">
-          <h3>⚙ Atelier technique</h3>
-          <span class="station-service-badge">Actif</span>
-        </div>
+                <div class="action-group">
+                    <div class="station-service-metric">
+                        <span class="station-service-label">Drone minier</span>
+                        <strong>{{ coutDroneMinier }} crédits / unité</strong>
+                    </div>
+                    <button class="action-button-with-icon" @click="emit('acheter-drone')">
+                        <span class="button-icon" aria-hidden="true">⇪</span>
+                        <span>Acheter un drone minier — {{ coutDroneMinier }} crédits</span>
+                    </button>
+                </div>
 
-        <div class="station-service-grid">
-          <div class="station-service-metric">
-            <span class="station-service-label">Service atelier</span>
-            <strong>Disponible</strong>
-          </div>
-
-          <div class="station-service-metric">
-            <span class="station-service-label">Capacité</span>
-            <strong>Maintenance légère</strong>
-          </div>
-        </div>
-
-        <p class="station-service-description">
-          Accès aux améliorations du vaisseau et à l’acquisition de drones miniers.
-        </p>
-
-        <div class="action-group">
-          <div class="station-service-metric">
-            <span class="station-service-label">Drone minier</span>
-            <strong>{{ coutDroneMinier }} crédits / unité</strong>
-          </div>
-          <button class="action-button-with-icon" @click="emit('acheter-drone')">
-            <span class="button-icon" aria-hidden="true">⇪</span>
-            <span>Acheter un drone minier — {{ coutDroneMinier }} crédits</span>
-          </button>
-        </div>
-
-        <div class="station-upgrade-shell">
-          <slot name="atelier" />
-        </div>
-      </div>
-    </template>
-  </section>
+                <div class="station-upgrade-shell">
+                    <slot name="atelier" />
+                </div>
+            </div>
+        </template>
+    </section>
 </template>

--- a/src/game/systemeReparation.js
+++ b/src/game/systemeReparation.js
@@ -1,0 +1,114 @@
+import { recupererEtatJeu } from './etatJeu'
+import { donneesSecteurs } from './dataSecteurs'
+import { ajouterAuJournal } from './systemeMinage'
+import { recupererVaisseauActif, synchroniserVaisseauActifDansEtat } from './systemeVaisseaux'
+
+const COUT_REPARATION_PAR_POINT = 15
+
+function recupererSecteurCourant(etat) {
+    return donneesSecteurs.find((secteur) => secteur.id === etat.secteurCourant?.id) || null
+}
+
+function recupererStationCourante(etat) {
+    return recupererSecteurCourant(etat)?.stationPrincipale ?? null
+}
+
+export function calculerPointsCoqueManquants(vaisseau) {
+    if (!vaisseau) {
+        return 0
+    }
+
+    const coqueMax = Number(vaisseau.coqueMax) || 0
+    const coque = Number(vaisseau.coque) || 0
+
+    return Math.max(0, coqueMax - coque)
+}
+
+export function calculerCoutReparationVaisseau(vaisseau) {
+    return calculerPointsCoqueManquants(vaisseau) * COUT_REPARATION_PAR_POINT
+}
+
+export function peutReparerVaisseauActif(etat = recupererEtatJeu()) {
+    if (etat.navigation?.enVoyage) {
+        return {
+            ok: false,
+            raison: 'Impossible de réparer un vaisseau pendant un trajet.',
+        }
+    }
+
+    if (etat.positionLocale !== 'station') {
+        return {
+            ok: false,
+            raison: 'Les réparations ne sont possibles qu’en station.',
+        }
+    }
+
+    const station = recupererStationCourante(etat)
+
+    if (!station?.services?.atelier) {
+        return {
+            ok: false,
+            raison: 'Aucun atelier disponible dans cette station.',
+        }
+    }
+
+    const vaisseauActif = recupererVaisseauActif(etat)
+
+    if (!vaisseauActif) {
+        return {
+            ok: false,
+            raison: 'Aucun vaisseau actif détecté.',
+        }
+    }
+
+    const pointsManquants = calculerPointsCoqueManquants(vaisseauActif)
+
+    if (pointsManquants <= 0) {
+        return {
+            ok: false,
+            raison: 'La coque est déjà à son niveau maximal.',
+        }
+    }
+
+    const coutReparation = calculerCoutReparationVaisseau(vaisseauActif)
+
+    if ((etat.ressources?.credits || 0) < coutReparation) {
+        return {
+            ok: false,
+            raison: 'Crédits insuffisants pour une réparation complète.',
+        }
+    }
+
+    return {
+        ok: true,
+        raison: null,
+        coutReparation,
+        pointsManquants,
+        vaisseauActif,
+    }
+}
+
+export function reparerVaisseauActif() {
+    const etat = recupererEtatJeu()
+    const validation = peutReparerVaisseauActif(etat)
+
+    if (!validation.ok) {
+        ajouterAuJournal(validation.raison, 'commerce', 'alerte')
+        return false
+    }
+
+    const { vaisseauActif, coutReparation, pointsManquants } = validation
+
+    etat.ressources.credits -= coutReparation
+    vaisseauActif.coque = vaisseauActif.coqueMax
+
+    synchroniserVaisseauActifDansEtat(etat)
+
+    ajouterAuJournal(
+        `Réparation complète effectuée sur ${vaisseauActif.nom} : +${pointsManquants} coque pour ${coutReparation} crédits.`,
+        'commerce',
+        'succes',
+    )
+
+    return true
+}


### PR DESCRIPTION
## Objet
Ajouter la réparation complète du vaisseau actif en station, via un atelier disponible localement.

## Contenu
- création du module `systemeReparation.js`
- ajout du calcul des points de coque manquants
- ajout du calcul du coût de réparation complète
- ajout de la logique de validation de la réparation :
  - station obligatoire
  - atelier obligatoire
  - vaisseau actif requis
  - coque endommagée
  - paiement intégral obligatoire
- restauration complète de la coque du vaisseau actif
- débit des crédits correspondants
- journalisation de l’opération
- intégration de l’action dans `App.vue`
- ajout de l’interface de réparation dans l’onglet Atelier de `StationServicesPanel.vue`
- désactivation du bouton si :
  - aucune réparation n’est nécessaire
  - les crédits sont insuffisants

## Résultat
- le joueur peut désormais réparer complètement son vaisseau actif dans une station équipée d’un atelier
- le coût de réparation est visible dans l’interface atelier
- la boucle coque devient complète :
  - dégâts
  - affichage
  - réparation

## Tests effectués
- dégâts de coque en exploitation
- retour en station avec atelier
- affichage du coût de réparation
- activation correcte du bouton si la réparation est possible
- désactivation du bouton si la coque est intacte
- désactivation du bouton si les crédits sont insuffisants
- restauration complète de la coque après réparation
- vérification du débit des crédits
- vérification du message dans le journal

## Notes
- réparation complète uniquement dans cette MR
- pas de réparation partielle à ce stade
- le coût est actuellement basé sur un tarif fixe par point de coque manquant
- cette MR prépare directement les tickets suivants liés au coût estimé et aux variantes de réparation