### PR TITLE
v0.3.14-52 : feat(atelier) : afficher un coût estimé de réparation plus lisible

### DIFF
--- a/src/assets/styles/features/station-services.css
+++ b/src/assets/styles/features/station-services.css
@@ -116,11 +116,25 @@
   margin-bottom: 8px;
 }
 
+.station-service-grid--atelier-devis {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 6px 8px;
+  margin-bottom: 6px;
+}
+
 .station-service-metric {
   padding: 8px 9px;
   border: 1px solid rgba(125, 184, 255, 0.08);
   border-radius: 8px;
   background: rgba(0, 0, 0, 0.12);
+}
+
+.station-service-metric--compact {
+  padding: 6px 8px;
+}
+
+.station-service-metric--support {
+  min-width: 160px;
 }
 
 .station-service-metric--full {
@@ -140,6 +154,23 @@
   font-style: italic;
   line-height: 1.16;
   opacity: 0.88;
+}
+
+.station-service-description--compact {
+  margin-bottom: 6px;
+  font-size: 0.8rem;
+  line-height: 1.12;
+}
+
+.action-group--atelier-main {
+  margin-top: 2px;
+  margin-bottom: 2px;
+}
+
+.action-group--atelier-support {
+  align-items: center;
+  gap: 8px;
+  margin-top: 4px;
 }
 
 /* ===== Listes station ===== */
@@ -211,9 +242,9 @@
 .station-launch-button {
   border: 1px solid rgba(102, 181, 255, 0.55);
   background: linear-gradient(
-    180deg,
-    rgba(34, 89, 148, 0.55) 0%,
-    rgba(20, 51, 90, 0.72) 100%
+          180deg,
+          rgba(34, 89, 148, 0.55) 0%,
+          rgba(20, 51, 90, 0.72) 100%
   );
   color: #d9ecff;
   box-shadow: inset 0 0 0 1px rgba(180, 220, 255, 0.08);
@@ -222,9 +253,9 @@
 .station-launch-button:hover:not(:disabled) {
   border-color: rgba(130, 200, 255, 0.8);
   background: linear-gradient(
-    180deg,
-    rgba(44, 112, 185, 0.62) 0%,
-    rgba(24, 63, 110, 0.82) 100%
+          180deg,
+          rgba(44, 112, 185, 0.62) 0%,
+          rgba(24, 63, 110, 0.82) 100%
   );
 }
 

--- a/src/components/StationServicesPanel.vue
+++ b/src/components/StationServicesPanel.vue
@@ -10,6 +10,7 @@ import {
 import {
     calculerCoutReparationVaisseau,
     calculerPointsCoqueManquants,
+    COUT_REPARATION_PAR_POINT,
 } from '../game/systemeReparation'
 
 const props = defineProps({
@@ -100,6 +101,8 @@ const reparationNecessaire = computed(() => pointsCoqueManquants.value > 0)
 const reparationAbordable = computed(
     () => reparationNecessaire.value && (props.ressources?.credits || 0) >= coutReparation.value,
 )
+
+const tarifAtelier = computed(() => `${COUT_REPARATION_PAR_POINT} cr / pt`)
 
 function recupererQuantiteEnSoute(idMinerai) {
     return props.ressources?.minerais?.[idMinerai] || 0
@@ -422,35 +425,34 @@ function vendreMineraiMax(minerai) {
                     <span class="station-service-badge">Actif</span>
                 </div>
 
-                <div class="station-service-grid">
-                    <div class="station-service-metric">
-                        <span class="station-service-label">Service atelier</span>
-                        <strong>Disponible</strong>
-                    </div>
-
-                    <div class="station-service-metric">
-                        <span class="station-service-label">Capacité</span>
-                        <strong>Maintenance légère</strong>
-                    </div>
-
-                    <div class="station-service-metric">
-                        <span class="station-service-label">Coque actuelle</span>
+                <div class="station-service-grid station-service-grid--atelier-devis">
+                    <div class="station-service-metric station-service-metric--compact">
+                        <span class="station-service-label">Coque</span>
                         <strong>{{ vaisseau.coque }} / {{ vaisseau.coqueMax }}</strong>
                     </div>
 
-                    <div class="station-service-metric">
-                        <span class="station-service-label">Réparation complète</span>
-                        <strong v-if="reparationNecessaire">{{ coutReparation }} crédits</strong>
-                        <strong v-else>Aucune nécessaire</strong>
+                    <div class="station-service-metric station-service-metric--compact">
+                        <span class="station-service-label">À réparer</span>
+                        <strong>{{ pointsCoqueManquants }} pts</strong>
+                    </div>
+
+                    <div class="station-service-metric station-service-metric--compact">
+                        <span class="station-service-label">Tarif atelier</span>
+                        <strong>{{ tarifAtelier }}</strong>
+                    </div>
+
+                    <div class="station-service-metric station-service-metric--compact">
+                        <span class="station-service-label">Coût estimé</span>
+                        <strong v-if="reparationNecessaire">{{ coutReparation }} cr</strong>
+                        <strong v-else>—</strong>
                     </div>
                 </div>
 
-                <p class="station-service-description">
-                    Accès aux réparations de coque, aux améliorations du vaisseau et à l’acquisition de drones
-                    miniers.
+                <p class="station-service-description station-service-description--compact">
+                    Réparation, amélioration et support technique du vaisseau actif.
                 </p>
 
-                <div class="action-group">
+                <div class="action-group action-group--atelier-main">
                     <button
                         class="action-button-with-icon"
                         :disabled="!reparationNecessaire || !reparationAbordable"
@@ -462,18 +464,19 @@ function vendreMineraiMax(minerai) {
                 </div>
 
                 <p v-if="!reparationNecessaire" class="panel-note">
-                    La coque du vaisseau actif est déjà à son niveau maximal.
+                    Coque intacte.
                 </p>
 
                 <p v-else-if="!reparationAbordable" class="panel-note panel-note-warning">
-                    Crédits insuffisants pour financer une réparation complète de la coque.
+                    Crédits insuffisants pour la réparation complète.
                 </p>
 
-                <div class="action-group">
-                    <div class="station-service-metric">
+                <div class="action-group action-group--atelier-support">
+                    <div class="station-service-metric station-service-metric--compact station-service-metric--support">
                         <span class="station-service-label">Drone minier</span>
-                        <strong>{{ coutDroneMinier }} crédits / unité</strong>
+                        <strong>{{ coutDroneMinier }} cr / unité</strong>
                     </div>
+
                     <button class="action-button-with-icon" @click="emit('acheter-drone')">
                         <span class="button-icon" aria-hidden="true">⇪</span>
                         <span>Acheter un drone minier — {{ coutDroneMinier }} crédits</span>

--- a/src/game/systemeReparation.js
+++ b/src/game/systemeReparation.js
@@ -3,7 +3,7 @@ import { donneesSecteurs } from './dataSecteurs'
 import { ajouterAuJournal } from './systemeMinage'
 import { recupererVaisseauActif, synchroniserVaisseauActifDansEtat } from './systemeVaisseaux'
 
-const COUT_REPARATION_PAR_POINT = 15
+export const COUT_REPARATION_PAR_POINT = 15
 
 function recupererSecteurCourant(etat) {
     return donneesSecteurs.find((secteur) => secteur.id === etat.secteurCourant?.id) || null


### PR DESCRIPTION
## Objet
Améliorer la lisibilité du coût de réparation du vaisseau actif dans l’atelier de station, sans alourdir visuellement le panneau des services.

## Contenu
- export du tarif atelier par point de coque depuis `systemeReparation.js`
- ajout d’un devis atelier compact dans l’onglet Atelier
- affichage explicite des informations utiles à la réparation :
  - coque actuelle
  - points à réparer
  - tarif atelier
  - coût estimé
- rationalisation du wording visible dans le bloc atelier
- réduction du texte d’accompagnement pour conserver une lecture rapide
- ajustements CSS fins dans `station-services.css` pour :
  - exploiter l’espace horizontal disponible
  - limiter l’encombrement visuel
  - conserver la cohérence du panneau

## Résultat
- le joueur comprend immédiatement combien de points de coque sont à restaurer
- le coût de réparation devient lisible sans ajouter de sous-panneau lourd
- l’atelier reste compact, clair et cohérent avec le reste de l’interface
- le ticket prépare naturellement les futures évolutions autour de la réparation partielle ou avancée

## Tests effectués
- affichage atelier avec coque intacte
- affichage atelier avec coque endommagée
- vérification des points à réparer
- vérification du tarif par point
- vérification du coût estimé total
- vérification de l’état du bouton de réparation selon :
  - coque intacte
  - coque endommagée
  - crédits suffisants / insuffisants
- validation visuelle de la compacité du panneau

## Notes
- aucune réparation partielle ajoutée dans cette MR
- aucune modification du comportement métier de réparation complète
- cette MR est centrée sur la visibilité, la compréhension du coût et la sobriété de l’UX