### PR TITLE
v0.3.14-99 : feat(atelier) : ajouter la réparation partielle et complète du vaisseau

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -24,7 +24,10 @@ import {
 import { acheterMineraiEnStation, vendreMineraiEnStation } from './game/systemeCommerce'
 import { ravitaillerCarburant } from './game/systemeRavitaillement'
 import { ameliorerVaisseau } from './game/systemeAmeliorations'
-import { reparerVaisseauActif } from './game/systemeReparation'
+import {
+    reparerPartiellementVaisseauActif,
+    reparerVaisseauActif,
+} from './game/systemeReparation'
 import {
     selectionnerDestination,
     lancerVoyageVersDestinationSelectionnee,
@@ -151,6 +154,12 @@ function gererRavitaillement() {
 
 function gererReparationVaisseau() {
     reparerVaisseauActif()
+    sauvegarderJeu()
+    synchroniserEtat()
+}
+
+function gererReparationPartielleVaisseau() {
+    reparerPartiellementVaisseauActif()
     sauvegarderJeu()
     synchroniserEtat()
 }
@@ -333,6 +342,7 @@ onUnmounted(() => {
                         @ravitailler="gererRavitaillement"
                         @acheter-drone="gererAchatDrone"
                         @reparer-vaisseau="gererReparationVaisseau"
+                        @reparer-partiellement-vaisseau="gererReparationPartielleVaisseau"
                         @retour-station="gererRetourStation"
                         @aller-operations="gererAllerOperations"
                     >

--- a/src/assets/styles/features/station-services.css
+++ b/src/assets/styles/features/station-services.css
@@ -122,6 +122,10 @@
   margin-bottom: 6px;
 }
 
+.station-service-grid--atelier-devis-5 {
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+}
+
 .station-service-metric {
   padding: 8px 9px;
   border: 1px solid rgba(125, 184, 255, 0.08);
@@ -165,6 +169,17 @@
 .action-group--atelier-main {
   margin-top: 2px;
   margin-bottom: 2px;
+}
+
+.action-group--atelier-main-split {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.action-group--atelier-main-split button {
+  width: 100%;
+  min-width: 0;
 }
 
 .action-group--atelier-support {

--- a/src/components/StationServicesPanel.vue
+++ b/src/components/StationServicesPanel.vue
@@ -8,8 +8,10 @@ import {
     formaterPourcentageTaxe,
 } from '../game/systemeCommerce'
 import {
+    calculerCoutReparationPartielleVaisseau,
     calculerCoutReparationVaisseau,
     calculerPointsCoqueManquants,
+    calculerPointsReparationPartielle,
     COUT_REPARATION_PAR_POINT,
 } from '../game/systemeReparation'
 
@@ -48,6 +50,7 @@ const emit = defineEmits([
     'ravitailler',
     'acheter-drone',
     'reparer-vaisseau',
+    'reparer-partiellement-vaisseau',
     'aller-operations',
     'retour-station',
 ])
@@ -93,13 +96,24 @@ const profilMarcheLabel = computed(() => {
 const coutDroneMinier = computed(() => props.economie?.coutDroneMinier ?? 400)
 
 const pointsCoqueManquants = computed(() => calculerPointsCoqueManquants(props.vaisseau))
+const pointsReparationPartielle = computed(() => calculerPointsReparationPartielle(props.vaisseau))
 
 const coutReparation = computed(() => calculerCoutReparationVaisseau(props.vaisseau))
+const coutReparationPartielle = computed(() =>
+    calculerCoutReparationPartielleVaisseau(props.vaisseau),
+)
 
 const reparationNecessaire = computed(() => pointsCoqueManquants.value > 0)
 
 const reparationAbordable = computed(
     () => reparationNecessaire.value && (props.ressources?.credits || 0) >= coutReparation.value,
+)
+
+const reparationPartielleAbordable = computed(
+    () =>
+        reparationNecessaire.value &&
+        pointsReparationPartielle.value > 0 &&
+        (props.ressources?.credits || 0) >= coutReparationPartielle.value,
 )
 
 const tarifAtelier = computed(() => `${COUT_REPARATION_PAR_POINT} cr / pt`)
@@ -425,7 +439,7 @@ function vendreMineraiMax(minerai) {
                     <span class="station-service-badge">Actif</span>
                 </div>
 
-                <div class="station-service-grid station-service-grid--atelier-devis">
+                <div class="station-service-grid station-service-grid--atelier-devis station-service-grid--atelier-devis-5">
                     <div class="station-service-metric station-service-metric--compact">
                         <span class="station-service-label">Coque</span>
                         <strong>{{ vaisseau.coque }} / {{ vaisseau.coqueMax }}</strong>
@@ -442,7 +456,13 @@ function vendreMineraiMax(minerai) {
                     </div>
 
                     <div class="station-service-metric station-service-metric--compact">
-                        <span class="station-service-label">Coût estimé</span>
+                        <span class="station-service-label">Coût partiel</span>
+                        <strong v-if="reparationNecessaire">{{ coutReparationPartielle }} cr</strong>
+                        <strong v-else>—</strong>
+                    </div>
+
+                    <div class="station-service-metric station-service-metric--compact">
+                        <span class="station-service-label">Coût complet</span>
                         <strong v-if="reparationNecessaire">{{ coutReparation }} cr</strong>
                         <strong v-else>—</strong>
                     </div>
@@ -452,14 +472,23 @@ function vendreMineraiMax(minerai) {
                     Réparation, amélioration et support technique du vaisseau actif.
                 </p>
 
-                <div class="action-group action-group--atelier-main">
+                <div class="action-group action-group--atelier-main action-group--atelier-main-split">
+                    <button
+                        class="action-button-with-icon"
+                        :disabled="!reparationNecessaire || !reparationPartielleAbordable"
+                        @click="emit('reparer-partiellement-vaisseau')"
+                    >
+                        <span class="button-icon" aria-hidden="true">🛠</span>
+                        <span>Réparation partielle (+{{ pointsReparationPartielle }})</span>
+                    </button>
+
                     <button
                         class="action-button-with-icon"
                         :disabled="!reparationNecessaire || !reparationAbordable"
                         @click="emit('reparer-vaisseau')"
                     >
                         <span class="button-icon" aria-hidden="true">🛠</span>
-                        <span>Réparer complètement le vaisseau</span>
+                        <span>Réparation complète</span>
                     </button>
                 </div>
 
@@ -467,12 +496,24 @@ function vendreMineraiMax(minerai) {
                     Coque intacte.
                 </p>
 
-                <p v-else-if="!reparationAbordable" class="panel-note panel-note-warning">
-                    Crédits insuffisants pour la réparation complète.
+                <p
+                    v-else-if="!reparationPartielleAbordable && !reparationAbordable"
+                    class="panel-note panel-note-warning"
+                >
+                    Crédits insuffisants pour toute réparation.
+                </p>
+
+                <p
+                    v-else-if="reparationPartielleAbordable && !reparationAbordable"
+                    class="panel-note panel-note-warning"
+                >
+                    Réparation partielle possible. Crédits insuffisants pour une réparation complète.
                 </p>
 
                 <div class="action-group action-group--atelier-support">
-                    <div class="station-service-metric station-service-metric--compact station-service-metric--support">
+                    <div
+                        class="station-service-metric station-service-metric--compact station-service-metric--support"
+                    >
                         <span class="station-service-label">Drone minier</span>
                         <strong>{{ coutDroneMinier }} cr / unité</strong>
                     </div>

--- a/src/game/systemeReparation.js
+++ b/src/game/systemeReparation.js
@@ -24,8 +24,22 @@ export function calculerPointsCoqueManquants(vaisseau) {
     return Math.max(0, coqueMax - coque)
 }
 
+export function calculerPointsReparationPartielle(vaisseau) {
+    const pointsManquants = calculerPointsCoqueManquants(vaisseau)
+
+    if (pointsManquants <= 0) {
+        return 0
+    }
+
+    return Math.max(1, Math.ceil(pointsManquants / 2))
+}
+
 export function calculerCoutReparationVaisseau(vaisseau) {
     return calculerPointsCoqueManquants(vaisseau) * COUT_REPARATION_PAR_POINT
+}
+
+export function calculerCoutReparationPartielleVaisseau(vaisseau) {
+    return calculerPointsReparationPartielle(vaisseau) * COUT_REPARATION_PAR_POINT
 }
 
 export function peutReparerVaisseauActif(etat = recupererEtatJeu()) {
@@ -88,6 +102,68 @@ export function peutReparerVaisseauActif(etat = recupererEtatJeu()) {
     }
 }
 
+export function peutReparerPartiellementVaisseauActif(etat = recupererEtatJeu()) {
+    if (etat.navigation?.enVoyage) {
+        return {
+            ok: false,
+            raison: 'Impossible de réparer un vaisseau pendant un trajet.',
+        }
+    }
+
+    if (etat.positionLocale !== 'station') {
+        return {
+            ok: false,
+            raison: 'Les réparations ne sont possibles qu’en station.',
+        }
+    }
+
+    const station = recupererStationCourante(etat)
+
+    if (!station?.services?.atelier) {
+        return {
+            ok: false,
+            raison: 'Aucun atelier disponible dans cette station.',
+        }
+    }
+
+    const vaisseauActif = recupererVaisseauActif(etat)
+
+    if (!vaisseauActif) {
+        return {
+            ok: false,
+            raison: 'Aucun vaisseau actif détecté.',
+        }
+    }
+
+    const pointsManquants = calculerPointsCoqueManquants(vaisseauActif)
+
+    if (pointsManquants <= 0) {
+        return {
+            ok: false,
+            raison: 'La coque est déjà à son niveau maximal.',
+        }
+    }
+
+    const pointsRepares = calculerPointsReparationPartielle(vaisseauActif)
+    const coutReparation = calculerCoutReparationPartielleVaisseau(vaisseauActif)
+
+    if ((etat.ressources?.credits || 0) < coutReparation) {
+        return {
+            ok: false,
+            raison: 'Crédits insuffisants pour une réparation partielle.',
+        }
+    }
+
+    return {
+        ok: true,
+        raison: null,
+        coutReparation,
+        pointsManquants,
+        pointsRepares,
+        vaisseauActif,
+    }
+}
+
 export function reparerVaisseauActif() {
     const etat = recupererEtatJeu()
     const validation = peutReparerVaisseauActif(etat)
@@ -106,6 +182,31 @@ export function reparerVaisseauActif() {
 
     ajouterAuJournal(
         `Réparation complète effectuée sur ${vaisseauActif.nom} : +${pointsManquants} coque pour ${coutReparation} crédits.`,
+        'commerce',
+        'succes',
+    )
+
+    return true
+}
+
+export function reparerPartiellementVaisseauActif() {
+    const etat = recupererEtatJeu()
+    const validation = peutReparerPartiellementVaisseauActif(etat)
+
+    if (!validation.ok) {
+        ajouterAuJournal(validation.raison, 'commerce', 'alerte')
+        return false
+    }
+
+    const { vaisseauActif, coutReparation, pointsRepares } = validation
+
+    etat.ressources.credits -= coutReparation
+    vaisseauActif.coque = Math.min(vaisseauActif.coque + pointsRepares, vaisseauActif.coqueMax)
+
+    synchroniserVaisseauActifDansEtat(etat)
+
+    ajouterAuJournal(
+        `Réparation partielle effectuée sur ${vaisseauActif.nom} : +${pointsRepares} coque pour ${coutReparation} crédits.`,
         'commerce',
         'succes',
     )


### PR DESCRIPTION
## Objet
Étendre le système de réparation en atelier afin de proposer deux options distinctes sur le vaisseau actif :
- réparation partielle
- réparation complète

## Contenu
- ajout du calcul des points restaurés en réparation partielle
- ajout du calcul du coût de réparation partielle
- ajout de la validation métier dédiée à la réparation partielle
- ajout de l’action de réparation partielle du vaisseau actif
- conservation du comportement existant pour la réparation complète
- intégration du nouveau flux dans `App.vue`
- évolution de l’onglet Atelier pour afficher :
  - coque actuelle
  - points à réparer
  - tarif atelier
  - coût partiel
  - coût complet
- ajout de deux boutons distincts :
  - réparation partielle
  - réparation complète
- gestion fine de l’activation/désactivation selon :
  - état de coque
  - crédits disponibles
- ajustements CSS ciblés pour conserver une interface compacte et lisible

## Résultat
- le joueur peut désormais choisir entre une réparation partielle ou complète
- la réparation partielle devient une réponse économique intermédiaire quand les crédits sont limités
- le coût des réparations est plus explicite et plus exploitable dans l’atelier
- l’UX atelier reste dense, lisible et cohérente avec le reste du panneau

## Règles retenues
- réparation partielle = 50 % des points de coque manquants, arrondi à l’entier supérieur
- réparation complète = restauration intégrale de la coque manquante
- les coûts suivent strictement le nombre de points restaurés
- atelier obligatoire
- station obligatoire
- vaisseau actif uniquement

## Tests effectués
- coque intacte : aucune réparation disponible
- coque endommagée avec crédits suffisants : réparation partielle et complète disponibles
- coque endommagée avec crédits suffisants uniquement pour la partielle : partielle disponible, complète indisponible
- réparation partielle : restauration correcte de la moitié des points manquants
- réparation complète : restauration intégrale de la coque
- vérification des coûts affichés dans l’atelier
- vérification des messages dans le journal
- validation visuelle de la compacité du panneau Atelier

## Notes
- cette MR n’ajoute pas encore de restrictions d’action liées à une coque critique
- elle prépare directement le prochain ticket sur les conséquences gameplay de l’état de coque
- l’interface reste volontairement simple, sans curseur libre ni réglage manuel du montant réparé

