### PR TITLE
v0.3.14-102 : refactor(ui) : centraliser les états visuels de coque, risque et alertes

### DIFF
--- a/src/components/OperationPanel.vue
+++ b/src/components/OperationPanel.vue
@@ -2,6 +2,12 @@
 import { computed } from 'vue'
 import { donneesMinerais } from '../game/dataMinerais'
 import { recupererEtatCoque } from '../game/systemeCoque'
+import {
+    recupererEtatVisuelBandeau,
+    recupererEtatVisuelCoque,
+    recupererEtatVisuelRisque,
+    recupererEtatVisuelScan,
+} from '../game/systemeEtatsVisuels'
 
 const props = defineProps({
     ressources: {
@@ -46,6 +52,8 @@ const emit = defineEmits([
 const infosCoque = computed(() =>
     recupererEtatCoque(props.vaisseau?.coque ?? 0, props.vaisseau?.coqueMax ?? 0),
 )
+
+const etatVisuelCoque = computed(() => recupererEtatVisuelCoque(infosCoque.value.code))
 
 const coqueCritique = computed(() => infosCoque.value.code === 'critique')
 const coqueHorsService = computed(() => infosCoque.value.code === 'hors_service')
@@ -143,36 +151,19 @@ const typeScannerLabel = computed(() => {
     return 'Module de base'
 })
 
-const qualiteScanLabel = computed(() => {
-    const qualite = props.exploration?.siteActif?.qualiteScan
-    if (qualite === 'bonne') return 'Bonne'
-    if (qualite === 'moyenne') return 'Moyenne'
-    if (qualite === 'faible') return 'Faible'
-    return '—'
-})
+const etatVisuelScan = computed(() =>
+    recupererEtatVisuelScan(props.exploration?.siteActif?.qualiteScan),
+)
 
-const qualiteScanClasse = computed(() => {
-    const qualite = props.exploration?.siteActif?.qualiteScan
-    if (qualite === 'bonne') return 'ops-badge-scan-bonne'
-    if (qualite === 'moyenne') return 'ops-badge-scan-moyenne'
-    if (qualite === 'faible') return 'ops-badge-scan-faible'
-    return 'ops-badge-scan-neutre'
-})
-
-const risqueAmasLabel = computed(() => {
-    const risque = props.exploration?.siteActif?.libelleRisque
-    if (!risque) return '—'
-    return risque.charAt(0).toUpperCase() + risque.slice(1)
-})
-
-const risqueAmasClasse = computed(() => {
-    const niveauRisque = Number(props.exploration?.siteActif?.niveauRisque || 0)
-
-    if (niveauRisque <= 0) return 'ops-badge-risk-negligeable'
-    if (niveauRisque === 1) return 'ops-badge-risk-faible'
-    if (niveauRisque === 2) return 'ops-badge-risk-modere'
-    return 'ops-badge-risk-eleve'
-})
+const etatVisuelRisque = computed(() =>
+    recupererEtatVisuelRisque(
+        props.exploration?.siteActif?.niveauRisque,
+        props.exploration?.siteActif?.libelleRisque
+            ? props.exploration.siteActif.libelleRisque.charAt(0).toUpperCase() +
+            props.exploration.siteActif.libelleRisque.slice(1)
+            : null,
+    ),
+)
 
 const reserveSiteLabel = computed(() => {
     const site = props.exploration?.siteActif
@@ -286,14 +277,9 @@ const statutOperationnel = computed(() => {
     }
 })
 
-const statutOperationnelClasse = computed(() => {
-    const niveau = statutOperationnel.value.niveau
-    if (niveau === 'critique') return 'ops-status-critical'
-    if (niveau === 'alerte') return 'ops-status-warning'
-    if (niveau === 'succes') return 'ops-status-success'
-    if (niveau === 'info') return 'ops-status-info'
-    return 'ops-status-standard'
-})
+const etatVisuelBandeau = computed(() =>
+    recupererEtatVisuelBandeau(statutOperationnel.value.niveau),
+)
 
 const scannerDisponible = computed(
     () =>
@@ -383,7 +369,7 @@ function decrireDrone(drone) {
             </div>
         </div>
 
-        <section class="ops-status-banner" :class="statutOperationnelClasse">
+        <section class="ops-status-banner" :class="etatVisuelBandeau.classeBandeau">
             <div class="ops-status-banner-head">
                 <span class="ops-status-dot"></span>
                 <strong>{{ statutOperationnel.titre }}</strong>
@@ -458,6 +444,11 @@ function decrireDrone(drone) {
               {{ industrie.drones.length }} / {{ vaisseau.dronesMiniersMax }}
             </span>
                     </div>
+
+                    <div class="ops-system-item">
+                        <span class="ops-system-name">État coque</span>
+                        <span class="ops-system-value">{{ etatVisuelCoque.label }}</span>
+                    </div>
                 </div>
             </section>
         </div>
@@ -468,12 +459,12 @@ function decrireDrone(drone) {
                     <h3>Exploitation</h3>
 
                     <div v-if="exploration.siteActif" class="ops-header-badges">
-            <span class="ops-badge-scan" :class="qualiteScanClasse">
-              {{ qualiteScanLabel }}
+            <span class="ops-badge-scan" :class="etatVisuelScan.classeBadge">
+              {{ etatVisuelScan.label }}
             </span>
 
-                        <span class="ops-badge-risk" :class="risqueAmasClasse">
-              Risque {{ risqueAmasLabel }}
+                        <span class="ops-badge-risk" :class="etatVisuelRisque.classeBadge">
+              Risque {{ etatVisuelRisque.label }}
             </span>
                     </div>
                 </div>

--- a/src/components/ShipPanel.vue
+++ b/src/components/ShipPanel.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { computed } from 'vue'
 import { recupererEtatCoque } from '../game/systemeCoque'
+import { recupererEtatVisuelCoque } from '../game/systemeEtatsVisuels'
 
 const props = defineProps({
     vaisseau: {
@@ -57,21 +58,7 @@ const infosCoque = computed(() =>
     recupererEtatCoque(props.vaisseau?.coque ?? 0, props.vaisseau?.coqueMax ?? 0),
 )
 
-const badgeCoqueClasse = computed(() => {
-    if (infosCoque.value.code === 'hors_service') {
-        return 'ship-hull-badge ship-hull-badge--hors-service'
-    }
-
-    if (infosCoque.value.code === 'critique') {
-        return 'ship-hull-badge ship-hull-badge--critique'
-    }
-
-    if (infosCoque.value.code === 'degradee') {
-        return 'ship-hull-badge ship-hull-badge--degradee'
-    }
-
-    return 'ship-hull-badge ship-hull-badge--nominale'
-})
+const etatVisuelCoque = computed(() => recupererEtatVisuelCoque(infosCoque.value.code))
 
 const largeurBarreCoque = computed(() => `${infosCoque.value.pourcentage}%`)
 </script>
@@ -102,13 +89,13 @@ const largeurBarreCoque = computed(() => `${infosCoque.value.pourcentage}%`)
         <div class="ship-panel-hull-status ship-panel-hull-status--compact">
             <div class="ship-panel-hull-status-head">
                 <span class="ship-panel-hull-title">Intégrité de coque</span>
-                <span :class="badgeCoqueClasse">{{ infosCoque.label }}</span>
+                <span :class="etatVisuelCoque.classeBadge">{{ etatVisuelCoque.label }}</span>
             </div>
 
             <div class="ship-panel-hull-bar">
                 <div
                     class="ship-panel-hull-bar-fill"
-                    :class="badgeCoqueClasse"
+                    :class="etatVisuelCoque.classeBarre"
                     :style="{ width: largeurBarreCoque }"
                 ></div>
             </div>

--- a/src/game/systemeEtatsVisuels.js
+++ b/src/game/systemeEtatsVisuels.js
@@ -1,0 +1,144 @@
+export function recupererEtatVisuelCoque(codeEtat = 'nominale') {
+    if (codeEtat === 'hors_service') {
+        return {
+            code: 'hors_service',
+            label: 'Hors service',
+            classeBadge: 'ship-hull-badge ship-hull-badge--hors-service',
+            classeBarre: 'ship-hull-badge--hors-service',
+            niveauAlerte: 'critique',
+        }
+    }
+
+    if (codeEtat === 'critique') {
+        return {
+            code: 'critique',
+            label: 'Critique',
+            classeBadge: 'ship-hull-badge ship-hull-badge--critique',
+            classeBarre: 'ship-hull-badge--critique',
+            niveauAlerte: 'alerte',
+        }
+    }
+
+    if (codeEtat === 'degradee') {
+        return {
+            code: 'degradee',
+            label: 'Dégradée',
+            classeBadge: 'ship-hull-badge ship-hull-badge--degradee',
+            classeBarre: 'ship-hull-badge--degradee',
+            niveauAlerte: 'alerte',
+        }
+    }
+
+    return {
+        code: 'nominale',
+        label: 'Nominale',
+        classeBadge: 'ship-hull-badge ship-hull-badge--nominale',
+        classeBarre: 'ship-hull-badge--nominale',
+        niveauAlerte: 'succes',
+    }
+}
+
+export function recupererEtatVisuelRisque(niveauRisque = 0, libelleRisque = null) {
+    const niveau = Number(niveauRisque || 0)
+
+    if (niveau <= 0) {
+        return {
+            niveau: 0,
+            label: libelleRisque || 'Négligeable',
+            classeBadge: 'ops-badge-risk-negligeable',
+            niveauAlerte: 'standard',
+        }
+    }
+
+    if (niveau === 1) {
+        return {
+            niveau: 1,
+            label: libelleRisque || 'Faible',
+            classeBadge: 'ops-badge-risk-faible',
+            niveauAlerte: 'info',
+        }
+    }
+
+    if (niveau === 2) {
+        return {
+            niveau: 2,
+            label: libelleRisque || 'Modéré',
+            classeBadge: 'ops-badge-risk-modere',
+            niveauAlerte: 'alerte',
+        }
+    }
+
+    return {
+        niveau: 3,
+        label: libelleRisque || 'Élevé',
+        classeBadge: 'ops-badge-risk-eleve',
+        niveauAlerte: 'critique',
+    }
+}
+
+export function recupererEtatVisuelScan(qualiteScan = null) {
+    if (qualiteScan === 'bonne') {
+        return {
+            label: 'Bonne',
+            classeBadge: 'ops-badge-scan-bonne',
+            niveauAlerte: 'succes',
+        }
+    }
+
+    if (qualiteScan === 'moyenne') {
+        return {
+            label: 'Moyenne',
+            classeBadge: 'ops-badge-scan-moyenne',
+            niveauAlerte: 'info',
+        }
+    }
+
+    if (qualiteScan === 'faible') {
+        return {
+            label: 'Faible',
+            classeBadge: 'ops-badge-scan-faible',
+            niveauAlerte: 'alerte',
+        }
+    }
+
+    return {
+        label: '—',
+        classeBadge: 'ops-badge-scan-neutre',
+        niveauAlerte: 'standard',
+    }
+}
+
+export function recupererEtatVisuelBandeau(niveau = 'standard') {
+    if (niveau === 'critique') {
+        return {
+            niveau: 'critique',
+            classeBandeau: 'ops-status-critical',
+        }
+    }
+
+    if (niveau === 'alerte') {
+        return {
+            niveau: 'alerte',
+            classeBandeau: 'ops-status-warning',
+        }
+    }
+
+    if (niveau === 'succes') {
+        return {
+            niveau: 'succes',
+            classeBandeau: 'ops-status-success',
+        }
+    }
+
+    if (niveau === 'info') {
+        return {
+            niveau: 'info',
+            classeBandeau: 'ops-status-info',
+        }
+    }
+
+    return {
+        niveau: 'standard',
+        classeBandeau: 'ops-status-standard',
+    }
+}


### PR DESCRIPTION
## Objet
Centraliser la logique visuelle liée aux états de coque, aux niveaux de risque et aux bandeaux d’alerte afin d’éviter la duplication de règles dans les composants d’interface.

## Contenu
- création du module `systemeEtatsVisuels.js`
- centralisation des correspondances visuelles pour :
  - les états de coque
  - les niveaux de risque
  - les qualités de scan
  - les bandeaux de statut
- refactorisation de `ShipPanel.vue` pour consommer les états visuels centralisés
- refactorisation de `OperationPanel.vue` pour consommer les états visuels centralisés
- conservation des classes CSS existantes afin de ne pas modifier le design global
- suppression de logique locale redondante dans les composants

## Résultat
- la logique état → label → classe visuelle est désormais regroupée dans un point unique
- les composants d’interface deviennent plus simples à lire et à maintenir
- les futures évolutions visuelles autour de la coque, du risque et des alertes seront plus sûres et plus cohérentes
- cette MR prépare directement les prochains tickets d’enrichissement visuel du panneau central

## Bénéfices techniques
- réduction de la duplication
- meilleure cohérence entre panneaux
- maintenance facilitée
- base saine pour les tickets suivants liés aux feedbacks visuels

## Tests effectués
- vérification du rendu du `ShipPanel` selon les différents états de coque
- vérification des badges de risque dans `OperationPanel`
- vérification des badges de qualité de scan
- vérification des bandeaux de statut :
  - standard
  - info
  - succès
  - alerte
  - critique
- vérification de l’absence de régression visuelle sur les composants refactorisés

## Notes
- cette MR n’introduit pas de nouveau design
- elle ne modifie pas le gameplay
- elle prépare surtout les prochains tickets visuels de la v0.3.14