### PR TITLE
v0.3.14-56 : feat(operations): ajouter les badges visuels de phase et de risque

### DIFF
--- a/src/assets/styles/features/operations.css
+++ b/src/assets/styles/features/operations.css
@@ -128,6 +128,122 @@
   line-height: 1.08;
 }
 
+/* ===== Bandeau de statut ===== */
+
+.ops-status-banner {
+  margin-bottom: 10px;
+  padding: 0.9rem 1rem;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.045);
+}
+
+.ops-status-banner-head {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  margin-bottom: 0.3rem;
+}
+
+.ops-status-banner p {
+  margin: 0;
+  line-height: 1.35;
+  opacity: 0.92;
+}
+
+.ops-status-dot {
+  width: 0.65rem;
+  height: 0.65rem;
+  border-radius: 999px;
+  background: currentColor;
+  box-shadow: 0 0 10px currentColor;
+}
+
+.ops-status-standard {
+  color: #d6dde6;
+  background: rgba(120, 132, 146, 0.14);
+  border-color: rgba(160, 172, 186, 0.2);
+}
+
+.ops-status-info {
+  color: #b8d7ff;
+  background: rgba(46, 95, 160, 0.18);
+  border-color: rgba(92, 150, 220, 0.26);
+}
+
+.ops-status-success {
+  color: #b9f0c9;
+  background: rgba(39, 122, 73, 0.18);
+  border-color: rgba(86, 196, 124, 0.26);
+}
+
+.ops-status-warning {
+  color: #f5d7a1;
+  background: rgba(168, 104, 32, 0.18);
+  border-color: rgba(214, 146, 58, 0.26);
+}
+
+.ops-status-critical {
+  color: #ffb8b8;
+  background: rgba(150, 44, 44, 0.2);
+  border-color: rgba(224, 90, 90, 0.28);
+}
+
+/* ===== Ruban de phases ===== */
+
+.ops-phase-strip {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  flex-wrap: wrap;
+  margin: -2px 0 10px 0;
+}
+
+.ops-phase-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 28px;
+  padding: 0.3rem 0.72rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  font-size: 0.75rem;
+  font-weight: 700;
+  line-height: 1;
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+}
+
+.ops-phase-badge--standard {
+  color: #c8d0da;
+  background: rgba(120, 132, 146, 0.16);
+  border-color: rgba(160, 172, 186, 0.24);
+}
+
+.ops-phase-badge--info {
+  color: #b8d7ff;
+  background: rgba(46, 95, 160, 0.22);
+  border-color: rgba(92, 150, 220, 0.4);
+}
+
+.ops-phase-badge--success {
+  color: #b9f0c9;
+  background: rgba(39, 122, 73, 0.22);
+  border-color: rgba(86, 196, 124, 0.4);
+}
+
+.ops-phase-badge--warning {
+  color: #f5d7a1;
+  background: rgba(168, 104, 32, 0.22);
+  border-color: rgba(214, 146, 58, 0.4);
+}
+
+.ops-phase-badge--danger {
+  color: #ffb8b8;
+  background: rgba(150, 44, 44, 0.22);
+  border-color: rgba(224, 90, 90, 0.38);
+}
+
 /* ===== Bandeau de commandes immédiates ===== */
 
 .ops-quick-actions {
@@ -179,6 +295,16 @@
 
 .ops-quick-button .button-icon {
   margin-right: 0.3rem;
+}
+
+/* ===== Header de blocs ===== */
+
+.ops-block-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 0.55rem;
 }
 
 /* ===== Badges de header de bloc ===== */
@@ -317,67 +443,6 @@
   font-size: 0.74rem;
   opacity: 0.8;
   line-height: 1.08;
-}
-
-/* ===== Bandeau de statut ===== */
-
-.ops-status-banner {
-  margin-bottom: 10px;
-  padding: 0.9rem 1rem;
-  border-radius: 12px;
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  background: rgba(255, 255, 255, 0.045);
-}
-
-.ops-status-banner-head {
-  display: flex;
-  align-items: center;
-  gap: 0.55rem;
-  margin-bottom: 0.3rem;
-}
-
-.ops-status-banner p {
-  margin: 0;
-  line-height: 1.35;
-  opacity: 0.92;
-}
-
-.ops-status-dot {
-  width: 0.65rem;
-  height: 0.65rem;
-  border-radius: 999px;
-  background: currentColor;
-  box-shadow: 0 0 10px currentColor;
-}
-
-.ops-status-standard {
-  color: #d6dde6;
-  background: rgba(120, 132, 146, 0.14);
-  border-color: rgba(160, 172, 186, 0.2);
-}
-
-.ops-status-info {
-  color: #b8d7ff;
-  background: rgba(46, 95, 160, 0.18);
-  border-color: rgba(92, 150, 220, 0.26);
-}
-
-.ops-status-success {
-  color: #b9f0c9;
-  background: rgba(39, 122, 73, 0.18);
-  border-color: rgba(86, 196, 124, 0.26);
-}
-
-.ops-status-warning {
-  color: #f5d7a1;
-  background: rgba(168, 104, 32, 0.18);
-  border-color: rgba(214, 146, 58, 0.26);
-}
-
-.ops-status-critical {
-  color: #ffb8b8;
-  background: rgba(150, 44, 44, 0.2);
-  border-color: rgba(224, 90, 90, 0.28);
 }
 
 /* ===== Grilles et blocs ===== */

--- a/src/components/OperationPanel.vue
+++ b/src/components/OperationPanel.vue
@@ -3,6 +3,7 @@ import { computed } from 'vue'
 import { donneesMinerais } from '../game/dataMinerais'
 import { recupererEtatCoque } from '../game/systemeCoque'
 import {
+    recupererBadgesOperationnels,
     recupererEtatVisuelBandeau,
     recupererEtatVisuelCoque,
     recupererEtatVisuelRisque,
@@ -123,9 +124,7 @@ const doctrineOperationnelle = computed(() => {
     return 'Prospection et exploitation locale'
 })
 
-const statutVolLabel = computed(() =>
-    props.navigation.enVoyage ? 'Transit' : 'Local',
-)
+const statutVolLabel = computed(() => (props.navigation.enVoyage ? 'Transit' : 'Local'))
 
 const statutCanon = computed(() => {
     if ((props.vaisseau?.puissanceMiniere || 0) <= 0) return 'Aucun canon'
@@ -151,6 +150,14 @@ const typeScannerLabel = computed(() => {
     return 'Module de base'
 })
 
+const libelleRisqueCapitalise = computed(() => {
+    const libelle = props.exploration?.siteActif?.libelleRisque
+
+    if (!libelle) return null
+
+    return libelle.charAt(0).toUpperCase() + libelle.slice(1)
+})
+
 const etatVisuelScan = computed(() =>
     recupererEtatVisuelScan(props.exploration?.siteActif?.qualiteScan),
 )
@@ -158,11 +165,22 @@ const etatVisuelScan = computed(() =>
 const etatVisuelRisque = computed(() =>
     recupererEtatVisuelRisque(
         props.exploration?.siteActif?.niveauRisque,
-        props.exploration?.siteActif?.libelleRisque
-            ? props.exploration.siteActif.libelleRisque.charAt(0).toUpperCase() +
-            props.exploration.siteActif.libelleRisque.slice(1)
-            : null,
+        libelleRisqueCapitalise.value,
     ),
+)
+
+const badgesOperationnels = computed(() =>
+    recupererBadgesOperationnels({
+        positionLocale: props.positionLocale,
+        enVoyage: props.navigation.enVoyage,
+        remorquageEnCours: props.assistance.remorquageEnCours,
+        siteActif: props.exploration?.siteActif,
+        niveauRisque: props.exploration?.siteActif?.niveauRisque,
+        libelleRisque: libelleRisqueCapitalise.value,
+        nbDeployes: nbDeployes.value,
+        coqueCode: infosCoque.value.code,
+        estTransporteurMarchand: estTransporteurMarchand.value,
+    }),
 )
 
 const reserveSiteLabel = computed(() => {
@@ -382,6 +400,16 @@ function decrireDrone(drone) {
             <p>{{ statutOperationnel.texte }}</p>
         </section>
 
+        <section v-if="badgesOperationnels.length > 0" class="ops-phase-strip">
+            <span
+                v-for="badge in badgesOperationnels"
+                :key="badge.id"
+                :class="badge.classe"
+            >
+                {{ badge.label }}
+            </span>
+        </section>
+
         <section v-if="afficherActionsRapides" class="ops-quick-actions">
             <div class="ops-quick-actions-head">
                 <strong>Commandes immédiates</strong>
@@ -437,13 +465,13 @@ function decrireDrone(drone) {
                     <h3>Exploitation</h3>
 
                     <div v-if="exploration.siteActif" class="ops-header-badges">
-            <span class="ops-badge-scan" :class="etatVisuelScan.classeBadge">
-              {{ etatVisuelScan.label }}
-            </span>
+                        <span class="ops-badge-scan" :class="etatVisuelScan.classeBadge">
+                            {{ etatVisuelScan.label }}
+                        </span>
 
                         <span class="ops-badge-risk" :class="etatVisuelRisque.classeBadge">
-              Risque {{ etatVisuelRisque.label }}
-            </span>
+                            Risque {{ etatVisuelRisque.label }}
+                        </span>
                     </div>
                 </div>
 
@@ -507,8 +535,8 @@ function decrireDrone(drone) {
                     <div class="ops-system-item">
                         <span class="ops-system-name">Baie à drones</span>
                         <span class="ops-system-value">
-              {{ industrie.drones.length }} / {{ vaisseau.dronesMiniersMax }}
-            </span>
+                            {{ industrie.drones.length }} / {{ vaisseau.dronesMiniersMax }}
+                        </span>
                     </div>
 
                     <div class="ops-system-item">
@@ -523,8 +551,8 @@ function decrireDrone(drone) {
             <div class="ops-block-header">
                 <h3>Drones</h3>
                 <span class="ops-drone-summary">
-          {{ nbDeployes }} déployé(s) · {{ nbPrets }} prêt(s) · {{ nbEnRecharge }} en recharge
-        </span>
+                    {{ nbDeployes }} déployé(s) · {{ nbPrets }} prêt(s) · {{ nbEnRecharge }} en recharge
+                </span>
             </div>
 
             <div class="ops-drone-counters">

--- a/src/game/systemeEtatsVisuels.js
+++ b/src/game/systemeEtatsVisuels.js
@@ -51,6 +51,7 @@ export function recupererEtatVisuelRisque(niveauRisque = 0, libelleRisque = null
             label: libelleRisque || 'Négligeable',
             classeBadge: 'ops-badge-risk-negligeable',
             niveauAlerte: 'standard',
+            variante: 'standard',
         }
     }
 
@@ -60,6 +61,7 @@ export function recupererEtatVisuelRisque(niveauRisque = 0, libelleRisque = null
             label: libelleRisque || 'Faible',
             classeBadge: 'ops-badge-risk-faible',
             niveauAlerte: 'info',
+            variante: 'info',
         }
     }
 
@@ -69,6 +71,7 @@ export function recupererEtatVisuelRisque(niveauRisque = 0, libelleRisque = null
             label: libelleRisque || 'Modéré',
             classeBadge: 'ops-badge-risk-modere',
             niveauAlerte: 'alerte',
+            variante: 'warning',
         }
     }
 
@@ -77,6 +80,7 @@ export function recupererEtatVisuelRisque(niveauRisque = 0, libelleRisque = null
         label: libelleRisque || 'Élevé',
         classeBadge: 'ops-badge-risk-eleve',
         niveauAlerte: 'critique',
+        variante: 'danger',
     }
 }
 
@@ -86,6 +90,7 @@ export function recupererEtatVisuelScan(qualiteScan = null) {
             label: 'Bonne',
             classeBadge: 'ops-badge-scan-bonne',
             niveauAlerte: 'succes',
+            variante: 'success',
         }
     }
 
@@ -94,6 +99,7 @@ export function recupererEtatVisuelScan(qualiteScan = null) {
             label: 'Moyenne',
             classeBadge: 'ops-badge-scan-moyenne',
             niveauAlerte: 'info',
+            variante: 'info',
         }
     }
 
@@ -102,6 +108,7 @@ export function recupererEtatVisuelScan(qualiteScan = null) {
             label: 'Faible',
             classeBadge: 'ops-badge-scan-faible',
             niveauAlerte: 'alerte',
+            variante: 'warning',
         }
     }
 
@@ -109,6 +116,7 @@ export function recupererEtatVisuelScan(qualiteScan = null) {
         label: '—',
         classeBadge: 'ops-badge-scan-neutre',
         niveauAlerte: 'standard',
+        variante: 'standard',
     }
 }
 
@@ -145,4 +153,73 @@ export function recupererEtatVisuelBandeau(niveau = 'standard') {
         niveau: 'standard',
         classeBandeau: 'ops-status-standard',
     }
+}
+
+function creerBadgeOperation(id, label, variante = 'standard') {
+    return {
+        id,
+        label,
+        classe: `ops-phase-badge ops-phase-badge--${variante}`,
+    }
+}
+
+export function recupererBadgesOperationnels({
+                                                 positionLocale = 'station',
+                                                 enVoyage = false,
+                                                 remorquageEnCours = false,
+                                                 siteActif = null,
+                                                 niveauRisque = 0,
+                                                 libelleRisque = null,
+                                                 nbDeployes = 0,
+                                                 coqueCode = 'nominale',
+                                                 estTransporteurMarchand = false,
+                                             } = {}) {
+    const badges = []
+
+    if (remorquageEnCours) {
+        badges.push(creerBadgeOperation('phase-remorquage', 'Remorquage', 'danger'))
+    } else if (enVoyage) {
+        badges.push(creerBadgeOperation('phase-transit', 'Transit', 'info'))
+    } else if (positionLocale === 'station') {
+        badges.push(creerBadgeOperation('phase-station', 'En station', 'standard'))
+    } else {
+        badges.push(creerBadgeOperation('phase-operations', 'Zone d’opérations', 'warning'))
+    }
+
+    if (coqueCode === 'hors_service') {
+        badges.push(creerBadgeOperation('etat-coque', 'Coque hors service', 'danger'))
+    } else if (coqueCode === 'critique') {
+        badges.push(creerBadgeOperation('etat-coque', 'Maintenance requise', 'warning'))
+    } else if (positionLocale === 'operations' && !enVoyage && !remorquageEnCours) {
+        if (estTransporteurMarchand) {
+            badges.push(creerBadgeOperation('phase-role', 'Fret local', 'info'))
+        } else if (siteActif) {
+            badges.push(creerBadgeOperation('phase-action', 'Extraction prête', 'success'))
+        } else {
+            badges.push(creerBadgeOperation('phase-action', 'Prospection', 'info'))
+        }
+    }
+
+    if (positionLocale === 'operations' && siteActif) {
+        const risque = recupererEtatVisuelRisque(niveauRisque, libelleRisque)
+        badges.push(
+            creerBadgeOperation(
+                'niveau-risque',
+                `Risque ${risque.label}`,
+                risque.variante || 'standard',
+            ),
+        )
+    }
+
+    if (nbDeployes > 0) {
+        badges.push(
+            creerBadgeOperation(
+                'drones',
+                nbDeployes > 1 ? `${nbDeployes} drones déployés` : 'Drone déployé',
+                'info',
+            ),
+        )
+    }
+
+    return badges.slice(0, 4)
 }


### PR DESCRIPTION
## Objet
Implémentation du ticket #56 de la v0.3.14.

Cette MR enrichit le panneau **Opérations** avec des badges visuels compacts permettant d’identifier plus rapidement :
- la **phase d’action courante**
- le **niveau de risque opérationnel**
- certains **états contextuels** du vaisseau et de l’exploitation

## Modifications principales

### Centralisation visuelle
Extension de `systemeEtatsVisuels.js` pour gérer désormais :
- les badges de phase opérationnelle
- les badges de risque contextuel
- leur variante visuelle homogène

### OperationPanel
Ajout d’un **ruban de badges opérationnels** sous le bandeau de statut.

Les badges peuvent refléter selon le contexte :
- En station
- Zone d’opérations
- Transit
- Remorquage
- Prospection
- Extraction prête
- Fret local
- Maintenance requise
- Coque hors service
- Drone(s) déployé(s)
- Risque faible / modéré / élevé

### CSS
Ajout d’une nouvelle grammaire visuelle dans `operations.css` :
- `.ops-phase-strip`
- `.ops-phase-badge`
- variantes :
  - `--standard`
  - `--info`
  - `--success`
  - `--warning`
  - `--danger`

## Objectif UX
Le panneau Opérations conserve sa structure rationalisée, tout en améliorant la lecture immédiate de la situation sans alourdir l’interface.

## Fichiers modifiés
- `src/game/systemeEtatsVisuels.js`
- `src/components/OperationPanel.vue`
- `src/assets/styles/features/operations.css`

## Vérifications effectuées
- affichage en station
- affichage en zone d’opérations
- présence / absence d’amas actif
- niveaux de risque
- drones déployés
- coque critique / hors service
- absence de régression visuelle majeure sur le panneau Opérations