### PR TITLE
v0.3.15 - refactor(ui): isoler le style du panneau Pilote et compacter la navigation

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { computed, onMounted, onUnmounted, reactive } from 'vue'
+import PlayerPanel from './components/PlayerPanel.vue'
 import ResourcePanel from './components/ResourcePanel.vue'
 import ShipPanel from './components/ShipPanel.vue'
 import SectorPanel from './components/SectorPanel.vue'
@@ -15,22 +16,19 @@ import HangarPanel from './components/HangarPanel.vue'
 import { recupererEtatJeu, reinitialiserEtatJeu } from './game/etatJeu'
 import { chargerJeu, sauvegarderJeu } from './game/systemeSauvegarde'
 import {
-    minerMineraiManuellement,
-    vendreTousLesMinerais,
-    acheterDroneMinier,
-    deployerDrones,
-    rappelerDrones,
+  minerMineraiManuellement,
+  vendreTousLesMinerais,
+  acheterDroneMinier,
+  deployerDrones,
+  rappelerDrones,
 } from './game/systemeMinage'
 import { acheterMineraiEnStation, vendreMineraiEnStation } from './game/systemeCommerce'
 import { ravitaillerCarburant } from './game/systemeRavitaillement'
 import { ameliorerVaisseau } from './game/systemeAmeliorations'
+import { reparerPartiellementVaisseauActif, reparerVaisseauActif } from './game/systemeReparation'
 import {
-    reparerPartiellementVaisseauActif,
-    reparerVaisseauActif,
-} from './game/systemeReparation'
-import {
-    selectionnerDestination,
-    lancerVoyageVersDestinationSelectionnee,
+  selectionnerDestination,
+  lancerVoyageVersDestinationSelectionnee,
 } from './game/systemeNavigation'
 import { allerEnZoneOperations, retourALaStation } from './game/systemeLocalisation'
 import { scannerAmasMinier } from './game/systemeExploration'
@@ -41,217 +39,218 @@ import { acheterVaisseau, changerVaisseauActif } from './game/systemeVaisseaux'
 const etat = reactive({})
 
 function creerEtatUIInitial() {
-    return {
-        modeActif: 'station',
-        sousModeStation: 'commerce',
-    }
+  return {
+    modeActif: 'station',
+    sousModeStation: 'commerce',
+  }
 }
 
 const ui = reactive(creerEtatUIInitial())
 
 const secteurCourantComplet = computed(
-    () => donneesSecteurs.find((secteur) => secteur.id === etat.secteurCourant?.id) || null,
+  () => donneesSecteurs.find((secteur) => secteur.id === etat.secteurCourant?.id) || null,
 )
 
 const stationCourante = computed(() => secteurCourantComplet.value?.stationPrincipale ?? null)
 
 function normaliserSousModeStation() {
-    const services = stationCourante.value?.services
+  const services = stationCourante.value?.services
 
-    if (ui.sousModeStation === 'hangar') {
-        return
-    }
+  if (ui.sousModeStation === 'hangar') {
+    return
+  }
 
-    if (!services) {
-        ui.sousModeStation = 'hangar'
-        return
-    }
-
-    if (ui.sousModeStation === 'commerce' && services.commerce) return
-    if (ui.sousModeStation === 'ravitaillement' && services.ravitaillement) return
-    if (ui.sousModeStation === 'atelier' && services.atelier) return
-
+  if (!services) {
     ui.sousModeStation = 'hangar'
+    return
+  }
+
+  if (ui.sousModeStation === 'commerce' && services.commerce) return
+  if (ui.sousModeStation === 'ravitaillement' && services.ravitaillement) return
+  if (ui.sousModeStation === 'atelier' && services.atelier) return
+
+  ui.sousModeStation = 'hangar'
 }
 
 function synchroniserModeActifAvecPositionLocale() {
-    if (etat.positionLocale === 'station') {
-        ui.modeActif = 'station'
-        normaliserSousModeStation()
-        return
-    }
+  if (etat.positionLocale === 'station') {
+    ui.modeActif = 'station'
+    normaliserSousModeStation()
+    return
+  }
 
-    if (etat.positionLocale === 'operations') {
-        ui.modeActif = 'operations'
-    }
+  if (etat.positionLocale === 'operations') {
+    ui.modeActif = 'operations'
+  }
 }
 
 function synchroniserEtat() {
-    const etatCourant = structuredClone(recupererEtatJeu())
+  const etatCourant = structuredClone(recupererEtatJeu())
 
-    Object.keys(etat).forEach((cle) => {
-        delete etat[cle]
-    })
+  Object.keys(etat).forEach((cle) => {
+    delete etat[cle]
+  })
 
-    Object.assign(etat, etatCourant)
+  Object.assign(etat, etatCourant)
 
-    synchroniserModeActifAvecPositionLocale()
+  synchroniserModeActifAvecPositionLocale()
 }
 
 function gererMinageManuel() {
-    minerMineraiManuellement()
-    sauvegarderJeu()
-    synchroniserEtat()
+  minerMineraiManuellement()
+  sauvegarderJeu()
+  synchroniserEtat()
 }
 
 function gererScanner() {
-    scannerAmasMinier()
-    sauvegarderJeu()
-    synchroniserEtat()
+  scannerAmasMinier()
+  sauvegarderJeu()
+  synchroniserEtat()
 }
 
 function gererVenteMinerai() {
-    vendreTousLesMinerais()
-    sauvegarderJeu()
-    synchroniserEtat()
+  vendreTousLesMinerais()
+  sauvegarderJeu()
+  synchroniserEtat()
 }
 
 function gererVenteBien(idBien, quantite = 1) {
-    vendreMineraiEnStation(idBien, quantite)
-    sauvegarderJeu()
-    synchroniserEtat()
+  vendreMineraiEnStation(idBien, quantite)
+  sauvegarderJeu()
+  synchroniserEtat()
 }
 
 function gererAchatBien(idBien, quantite = 1) {
-    acheterMineraiEnStation(idBien, quantite)
-    sauvegarderJeu()
-    synchroniserEtat()
+  acheterMineraiEnStation(idBien, quantite)
+  sauvegarderJeu()
+  synchroniserEtat()
 }
 
 function gererAchatDrone() {
-    acheterDroneMinier()
-    sauvegarderJeu()
-    synchroniserEtat()
+  acheterDroneMinier()
+  sauvegarderJeu()
+  synchroniserEtat()
 }
 
 function gererDeploiementDrones() {
-    deployerDrones()
-    sauvegarderJeu()
-    synchroniserEtat()
+  deployerDrones()
+  sauvegarderJeu()
+  synchroniserEtat()
 }
 
 function gererRappelDrones() {
-    rappelerDrones()
-    sauvegarderJeu()
-    synchroniserEtat()
+  rappelerDrones()
+  sauvegarderJeu()
+  synchroniserEtat()
 }
 
 function gererRavitaillement() {
-    ravitaillerCarburant()
-    sauvegarderJeu()
-    synchroniserEtat()
+  ravitaillerCarburant()
+  sauvegarderJeu()
+  synchroniserEtat()
 }
 
 function gererReparationVaisseau() {
-    reparerVaisseauActif()
-    sauvegarderJeu()
-    synchroniserEtat()
+  reparerVaisseauActif()
+  sauvegarderJeu()
+  synchroniserEtat()
 }
 
 function gererReparationPartielleVaisseau() {
-    reparerPartiellementVaisseauActif()
-    sauvegarderJeu()
-    synchroniserEtat()
+  reparerPartiellementVaisseauActif()
+  sauvegarderJeu()
+  synchroniserEtat()
 }
 
 function gererVoyage() {
-    lancerVoyageVersDestinationSelectionnee()
-    sauvegarderJeu()
-    synchroniserEtat()
+  lancerVoyageVersDestinationSelectionnee()
+  sauvegarderJeu()
+  synchroniserEtat()
 }
 
 function gererSelectionDestination(idDestination) {
-    selectionnerDestination(idDestination)
-    sauvegarderJeu()
-    synchroniserEtat()
+  selectionnerDestination(idDestination)
+  sauvegarderJeu()
+  synchroniserEtat()
 }
 
 function gererAmelioration(idAmelioration) {
-    ameliorerVaisseau(idAmelioration)
-    sauvegarderJeu()
-    synchroniserEtat()
+  ameliorerVaisseau(idAmelioration)
+  sauvegarderJeu()
+  synchroniserEtat()
 }
 
 function gererAllerOperations() {
-    const positionAvant = etat.positionLocale
+  const positionAvant = etat.positionLocale
 
-    allerEnZoneOperations()
-    sauvegarderJeu()
-    synchroniserEtat()
+  allerEnZoneOperations()
+  sauvegarderJeu()
+  synchroniserEtat()
 
-    if (positionAvant !== etat.positionLocale && etat.positionLocale === 'operations') {
-        ui.modeActif = 'operations'
-    }
+  if (positionAvant !== etat.positionLocale && etat.positionLocale === 'operations') {
+    ui.modeActif = 'operations'
+  }
 }
 
 function gererRetourStation() {
-    const positionAvant = etat.positionLocale
+  const positionAvant = etat.positionLocale
 
-    retourALaStation()
-    sauvegarderJeu()
-    synchroniserEtat()
+  retourALaStation()
+  sauvegarderJeu()
+  synchroniserEtat()
 
-    if (positionAvant !== etat.positionLocale && etat.positionLocale === 'station') {
-        ui.modeActif = 'station'
-        normaliserSousModeStation()
-    }
+  if (positionAvant !== etat.positionLocale && etat.positionLocale === 'station') {
+    ui.modeActif = 'station'
+    normaliserSousModeStation()
+  }
 }
 
 function gererChangerVaisseau(idVaisseau) {
-    changerVaisseauActif(idVaisseau)
-    sauvegarderJeu()
-    synchroniserEtat()
+  changerVaisseauActif(idVaisseau)
+  sauvegarderJeu()
+  synchroniserEtat()
 }
 
 function gererAcheterVaisseau(modeleId) {
-    acheterVaisseau(modeleId)
-    sauvegarderJeu()
-    synchroniserEtat()
+  acheterVaisseau(modeleId)
+  sauvegarderJeu()
+  synchroniserEtat()
 }
 
 function gererReinitialisation() {
-    reinitialiserEtatJeu()
-    Object.assign(ui, creerEtatUIInitial())
-    sauvegarderJeu()
-    synchroniserEtat()
+  reinitialiserEtatJeu()
+  Object.assign(ui, creerEtatUIInitial())
+  sauvegarderJeu()
+  synchroniserEtat()
 }
 
 function changerMode(mode) {
-    ui.modeActif = mode
-    if (mode === 'station') {
-        normaliserSousModeStation()
-    }
+  ui.modeActif = mode
+  if (mode === 'station') {
+    normaliserSousModeStation()
+  }
 }
 
 function changerSousModeStation(sousMode) {
-    ui.sousModeStation = sousMode
+  ui.sousModeStation = sousMode
 }
 
 onMounted(() => {
-    chargerJeu()
-    synchroniserEtat()
-    demarrerBoucleJeu(synchroniserEtat)
+  chargerJeu()
+  synchroniserEtat()
+  demarrerBoucleJeu(synchroniserEtat)
 })
 
 onUnmounted(() => {
-    arreterBoucleJeu()
+  arreterBoucleJeu()
 })
 </script>
 
 <template>
-    <main
-        class="app-shell"
-        v-if="
+  <main
+    class="app-shell"
+    v-if="
+      etat.joueur &&
       etat.ressources &&
       etat.vaisseau &&
       etat.vaisseauxPossedes &&
@@ -264,128 +263,132 @@ onUnmounted(() => {
       etat.exploration &&
       etat.assistance
     "
-    >
-        <header class="app-header">
-            <div class="header-top">
-                <div class="header-brand">
-                    <h1 class="title-line">
-                        <span class="title-icon">✦</span>
-                        <span>New Horizon</span>
-                        <span class="title-icon">✦</span>
-                    </h1>
+  >
+    <header class="app-header">
+      <div class="header-top">
+        <div class="header-brand">
+          <h1 class="title-line">
+            <span class="title-icon">✦</span>
+            <span>New Horizon</span>
+            <span class="title-icon">✦</span>
+          </h1>
 
-                    <p class="subtitle">
-                        Simulation spatiale incrémentale de prospection minière et de commerce
-                    </p>
+          <p class="subtitle">
+            Simulation spatiale incrémentale de prospection minière et de commerce
+          </p>
 
-                    <p class="meta-line">
-                        v{{ etat.meta?.version }} — {{ etat.meta?.auteur }} — {{ etat.meta?.annee }}
-                    </p>
-                </div>
-
-                <HeaderActions
-                    :mode-actif="ui.modeActif"
-                    @changer-mode="changerMode"
-                    @reinitialiser="gererReinitialisation"
-                />
-            </div>
-        </header>
-
-        <div class="app-main">
-            <section class="main-column main-column-left">
-                <ResourcePanel
-                    :ressources="etat.ressources"
-                    :vaisseau="etat.vaisseau"
-                    :secteur-courant="etat.secteurCourant"
-                />
-                <ShipPanel :vaisseau="etat.vaisseau" :industrie="etat.industrie" />
-                <NavigationPanel
-                    :secteur-courant-id="etat.secteurCourant.id"
-                    :navigation="etat.navigation"
-                    :position-locale="etat.positionLocale"
-                    @selectionner-destination="gererSelectionDestination"
-                    @voyager="gererVoyage"
-                />
-            </section>
-
-            <section class="main-column main-column-center">
-                <div class="center-top">
-                    <OperationPanel
-                        v-if="ui.modeActif === 'operations'"
-                        :ressources="etat.ressources"
-                        :vaisseau="etat.vaisseau"
-                        :industrie="etat.industrie"
-                        :navigation="etat.navigation"
-                        :position-locale="etat.positionLocale"
-                        :exploration="etat.exploration"
-                        :assistance="etat.assistance"
-                        @miner="gererMinageManuel"
-                        @scanner="gererScanner"
-                        @aller-operations="gererAllerOperations"
-                        @retour-station="gererRetourStation"
-                        @deployer-drones="gererDeploiementDrones"
-                        @rappeler-drones="gererRappelDrones"
-                    />
-
-                    <StationServicesPanel
-                        v-else-if="ui.modeActif === 'station'"
-                        :secteur-courant="etat.secteurCourant"
-                        :vaisseau="etat.vaisseau"
-                        :ressources="etat.ressources"
-                        :sous-mode-station="ui.sousModeStation"
-                        :position-locale="etat.positionLocale"
-                        :economie="etat.economie"
-                        @changer-sous-mode-station="changerSousModeStation"
-                        @vendre="gererVenteMinerai"
-                        @vendre-bien="gererVenteBien"
-                        @acheter-bien="gererAchatBien"
-                        @ravitailler="gererRavitaillement"
-                        @acheter-drone="gererAchatDrone"
-                        @reparer-vaisseau="gererReparationVaisseau"
-                        @reparer-partiellement-vaisseau="gererReparationPartielleVaisseau"
-                        @retour-station="gererRetourStation"
-                        @aller-operations="gererAllerOperations"
-                    >
-                        <template #hangar>
-                            <HangarPanel
-                                :secteur-courant="etat.secteurCourant"
-                                :vaisseau-actif-id="etat.vaisseauActifId"
-                                :vaisseaux-possedes="etat.vaisseauxPossedes"
-                                :vaisseau="etat.vaisseau"
-                                :ressources="etat.ressources"
-                                @changer-vaisseau="gererChangerVaisseau"
-                                @acheter-vaisseau="gererAcheterVaisseau"
-                            />
-                        </template>
-
-                        <template #atelier>
-                            <UpgradePanel
-                                :vaisseau="etat.vaisseau"
-                                :secteur-courant="etat.secteurCourant"
-                                @ameliorer="gererAmelioration"
-                            />
-                        </template>
-                    </StationServicesPanel>
-
-                    <NavigationPanel
-                        v-else-if="ui.modeActif === 'navigation'"
-                        :secteur-courant-id="etat.secteurCourant.id"
-                        :navigation="etat.navigation"
-                        :position-locale="etat.positionLocale"
-                        @selectionner-destination="gererSelectionDestination"
-                        @voyager="gererVoyage"
-                    />
-                </div>
-
-                <section class="journal-panel">
-                    <LogPanel :entrees="etat.journal" />
-                </section>
-            </section>
-
-            <aside class="right-aside">
-                <SectorPanel :secteur-courant="etat.secteurCourant" />
-                <StationPanel :secteur-courant="etat.secteurCourant" />
-            </aside>
+          <p class="meta-line">
+            v{{ etat.meta?.version }} — {{ etat.meta?.auteur }} — {{ etat.meta?.annee }}
+          </p>
         </div>
-    </main>
+
+        <HeaderActions
+          :mode-actif="ui.modeActif"
+          @changer-mode="changerMode"
+          @reinitialiser="gererReinitialisation"
+        />
+      </div>
+    </header>
+
+    <div class="app-main">
+      <section class="main-column main-column-left">
+        <PlayerPanel :player="etat.joueur" :credits="etat.ressources.credits" />
+
+        <ResourcePanel
+          :ressources="etat.ressources"
+          :vaisseau="etat.vaisseau"
+          :secteur-courant="etat.secteurCourant"
+        />
+
+        <ShipPanel :vaisseau="etat.vaisseau" :industrie="etat.industrie" />
+
+        <NavigationPanel
+          :secteur-courant-id="etat.secteurCourant.id"
+          :navigation="etat.navigation"
+          :position-locale="etat.positionLocale"
+          @selectionner-destination="gererSelectionDestination"
+          @voyager="gererVoyage"
+        />
+      </section>
+
+      <section class="main-column main-column-center">
+        <div class="center-top">
+          <OperationPanel
+            v-if="ui.modeActif === 'operations'"
+            :ressources="etat.ressources"
+            :vaisseau="etat.vaisseau"
+            :industrie="etat.industrie"
+            :navigation="etat.navigation"
+            :position-locale="etat.positionLocale"
+            :exploration="etat.exploration"
+            :assistance="etat.assistance"
+            @miner="gererMinageManuel"
+            @scanner="gererScanner"
+            @aller-operations="gererAllerOperations"
+            @retour-station="gererRetourStation"
+            @deployer-drones="gererDeploiementDrones"
+            @rappeler-drones="gererRappelDrones"
+          />
+
+          <StationServicesPanel
+            v-else-if="ui.modeActif === 'station'"
+            :secteur-courant="etat.secteurCourant"
+            :vaisseau="etat.vaisseau"
+            :ressources="etat.ressources"
+            :sous-mode-station="ui.sousModeStation"
+            :position-locale="etat.positionLocale"
+            :economie="etat.economie"
+            @changer-sous-mode-station="changerSousModeStation"
+            @vendre="gererVenteMinerai"
+            @vendre-bien="gererVenteBien"
+            @acheter-bien="gererAchatBien"
+            @ravitailler="gererRavitaillement"
+            @acheter-drone="gererAchatDrone"
+            @reparer-vaisseau="gererReparationVaisseau"
+            @reparer-partiellement-vaisseau="gererReparationPartielleVaisseau"
+            @retour-station="gererRetourStation"
+            @aller-operations="gererAllerOperations"
+          >
+            <template #hangar>
+              <HangarPanel
+                :secteur-courant="etat.secteurCourant"
+                :vaisseau-actif-id="etat.vaisseauActifId"
+                :vaisseaux-possedes="etat.vaisseauxPossedes"
+                :vaisseau="etat.vaisseau"
+                :ressources="etat.ressources"
+                @changer-vaisseau="gererChangerVaisseau"
+                @acheter-vaisseau="gererAcheterVaisseau"
+              />
+            </template>
+
+            <template #atelier>
+              <UpgradePanel
+                :vaisseau="etat.vaisseau"
+                :secteur-courant="etat.secteurCourant"
+                @ameliorer="gererAmelioration"
+              />
+            </template>
+          </StationServicesPanel>
+
+          <NavigationPanel
+            v-else-if="ui.modeActif === 'navigation'"
+            :secteur-courant-id="etat.secteurCourant.id"
+            :navigation="etat.navigation"
+            :position-locale="etat.positionLocale"
+            @selectionner-destination="gererSelectionDestination"
+            @voyager="gererVoyage"
+          />
+        </div>
+
+        <section class="journal-panel">
+          <LogPanel :entrees="etat.journal" />
+        </section>
+      </section>
+
+      <aside class="right-aside">
+        <SectorPanel :secteur-courant="etat.secteurCourant" />
+        <StationPanel :secteur-courant="etat.secteurCourant" />
+      </aside>
+    </div>
+  </main>
 </template>

--- a/src/assets/styles/components/navigation.css
+++ b/src/assets/styles/components/navigation.css
@@ -20,11 +20,25 @@ select {
   color: #eef5fb;
 }
 
+.navigation-destination-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
 .navigation-label {
   display: block;
   margin-bottom: 5px;
   font-size: 0.88rem;
   opacity: 0.9;
+}
+
+.navigation-label--inline {
+  margin-bottom: 0;
+  font-size: 0.82rem;
+  white-space: nowrap;
 }
 
 .navigation-select {
@@ -35,6 +49,20 @@ select {
   border-radius: 6px;
   background: #0f1822;
   color: #eef5fb;
+}
+
+.navigation-select--compact {
+  margin-bottom: 0;
+  padding: 0.38rem 0.55rem;
+  font-size: 0.9rem;
+  line-height: 1.1;
+}
+
+.navigation-route-meta {
+  margin: 0 0 8px;
+  font-size: 0.8rem;
+  line-height: 1.1;
+  opacity: 0.88;
 }
 
 .navigation-status {

--- a/src/assets/styles/components/panels.css
+++ b/src/assets/styles/components/panels.css
@@ -17,10 +17,10 @@
   box-shadow: inset 0 0 0 1px rgba(125, 184, 255, 0.03);
   overflow: hidden;
   transition:
-          border-color var(--nh-motion-duration-fast) var(--nh-motion-ease-standard),
-          box-shadow var(--nh-motion-duration-fast) var(--nh-motion-ease-standard),
-          background var(--nh-motion-duration-fast) var(--nh-motion-ease-standard),
-          opacity var(--nh-motion-duration-fast) var(--nh-motion-ease-standard);
+    border-color var(--nh-motion-duration-fast) var(--nh-motion-ease-standard),
+    box-shadow var(--nh-motion-duration-fast) var(--nh-motion-ease-standard),
+    background var(--nh-motion-duration-fast) var(--nh-motion-ease-standard),
+    opacity var(--nh-motion-duration-fast) var(--nh-motion-ease-standard);
 }
 
 .panel h2 {

--- a/src/assets/styles/features/player.css
+++ b/src/assets/styles/features/player.css
@@ -1,0 +1,81 @@
+/* =========================================================
+   FEATURE — PILOTE
+   ---------------------------------------------------------
+   Rôle :
+   - panneau d’identité du joueur
+   - statut, réputation, fortune
+   - compacité adaptée à la colonne gauche
+   ========================================================= */
+
+.player-panel {
+  position: relative;
+  min-height: unset;
+  padding-bottom: 9px;
+}
+
+.player-panel::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background:
+    linear-gradient(135deg, rgba(125, 184, 255, 0.05), transparent 45%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.015), transparent 55%);
+  pointer-events: none;
+}
+
+.player-panel-header {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+
+.player-panel-header h2 {
+  margin-bottom: 0;
+}
+
+.player-panel-badge {
+  flex: 0 0 auto;
+  padding: 2px 7px;
+  border: 1px solid rgba(125, 184, 255, 0.18);
+  border-radius: 999px;
+  background: rgba(125, 184, 255, 0.08);
+  font-size: 0.64rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  opacity: 0.92;
+}
+
+.player-panel-grid {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 5px;
+}
+
+.player-panel-card {
+  padding: 5px 8px 5px;
+  border: 1px solid rgba(125, 184, 255, 0.08);
+  border-radius: 9px;
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.player-panel-label {
+  display: block;
+  margin-bottom: 1px;
+  font-size: 0.64rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  opacity: 0.66;
+}
+
+.player-panel-value {
+  display: block;
+  font-size: 0.84rem;
+  line-height: 1.05;
+  color: #d8e7f7;
+}

--- a/src/assets/styles/main.css
+++ b/src/assets/styles/main.css
@@ -41,6 +41,7 @@
    ========================================================= */
 @import './components/navigation.css';
 @import './components/resources.css';
+@import './features/player.css';
 
 /* =========================================================
    5. ZONE CENTRALE DE PILOTAGE

--- a/src/components/NavigationPanel.vue
+++ b/src/components/NavigationPanel.vue
@@ -12,16 +12,16 @@ const props = defineProps({
     type: Object,
     required: true,
   },
+  positionLocale: {
+    type: String,
+    default: 'station',
+  },
 })
 
 const emit = defineEmits(['selectionner-destination', 'voyager'])
 
 const secteurCourant = computed(() =>
   donneesSecteurs.find((secteur) => secteur.id === props.secteurCourantId),
-)
-
-const secteurDestinationSelectionnee = computed(() =>
-  donneesSecteurs.find((secteur) => secteur.id === props.navigation.destinationSelectionneeId),
 )
 
 const secteurDestinationActive = computed(() =>
@@ -46,6 +46,7 @@ const trajetSelectionne = computed(() =>
     <h2>⟁ Navigation</h2>
 
     <p>Secteur actuel : {{ secteurCourant?.nom }}</p>
+    <p>Position : {{ positionLocale === 'operations' ? 'Zone d’opérations' : 'Station' }}</p>
 
     <template v-if="navigation.enVoyage">
       <p>Destination : {{ secteurDestinationActive?.nom }}</p>
@@ -54,32 +55,38 @@ const trajetSelectionne = computed(() =>
     </template>
 
     <template v-else>
-      <label class="navigation-label" for="destination-select"> Destination </label>
+      <div class="navigation-destination-row">
+        <label class="navigation-label navigation-label--inline" for="destination-select">
+          Destination
+        </label>
 
-      <select
-        id="destination-select"
-        class="navigation-select"
-        :value="navigation.destinationSelectionneeId"
-        @change="emit('selectionner-destination', $event.target.value)"
-      >
-        <option v-for="secteur in autresSecteurs" :key="secteur.id" :value="secteur.id">
-          {{ secteur.nom }}
-        </option>
-      </select>
+        <select
+          id="destination-select"
+          class="navigation-select navigation-select--compact"
+          :value="navigation.destinationSelectionneeId"
+          @change="emit('selectionner-destination', $event.target.value)"
+        >
+          <option v-for="secteur in autresSecteurs" :key="secteur.id" :value="secteur.id">
+            {{ secteur.nom }}
+          </option>
+        </select>
+      </div>
 
-      <template v-if="secteurDestinationSelectionnee && trajetSelectionne">
-        <p>Coût carburant : {{ trajetSelectionne.coutCarburant }}</p>
-        <p>Durée du trajet : {{ trajetSelectionne.tempsTrajet }} ticks</p>
+      <template v-if="trajetSelectionne">
+        <p class="navigation-route-meta">
+          Durée : {{ trajetSelectionne.tempsTrajet }} ticks · Coût carburant :
+          {{ trajetSelectionne.coutCarburant }}
+        </p>
       </template>
 
       <div class="action-group">
-        <button class="action-button-with-icon" @click="$emit('voyager')">
+        <button class="action-button-with-icon" @click="emit('voyager')">
           <span class="button-icon" aria-hidden="true">🧭</span>
           <span>Lancer le trajet</span>
         </button>
       </div>
 
-      <p class="navigation-status">Statut : À quai</p>
+      <p class="navigation-status">Statut : Prêt au départ</p>
     </template>
   </section>
 </template>

--- a/src/components/PlayerPanel.vue
+++ b/src/components/PlayerPanel.vue
@@ -1,0 +1,45 @@
+<script setup>
+defineProps({
+  player: {
+    type: Object,
+    default: () => ({}),
+  },
+  credits: {
+    type: Number,
+    default: 0,
+  },
+})
+</script>
+
+<template>
+  <section class="panel player-panel">
+    <div class="player-panel-header">
+      <h2>◉ Pilote</h2>
+
+      <span class="player-panel-badge">
+        {{ player?.statut || 'Indépendant' }}
+      </span>
+    </div>
+
+    <div class="player-panel-grid">
+      <div class="player-panel-card">
+        <span class="player-panel-label">Identité</span>
+        <strong class="player-panel-value">
+          {{ player?.identite || 'À renseigner' }}
+        </strong>
+      </div>
+
+      <div class="player-panel-card">
+        <span class="player-panel-label">Réputation</span>
+        <strong class="player-panel-value">
+          {{ player?.reputation || 'Inconnue' }}
+        </strong>
+      </div>
+
+      <div class="player-panel-card">
+        <span class="player-panel-label">Fortune</span>
+        <strong class="player-panel-value"> {{ credits }} crédits </strong>
+      </div>
+    </div>
+  </section>
+</template>

--- a/src/components/ResourcePanel.vue
+++ b/src/components/ResourcePanel.vue
@@ -1,10 +1,7 @@
 <script setup>
-import { computed } from 'vue'
 import { donneesMinerais } from '../game/dataMinerais'
-import { donneesSecteurs } from '../game/dataSecteurs'
-import { calculerValeurCargaisonPourStation } from '../game/systemeCommerce'
 
-const props = defineProps({
+defineProps({
   ressources: {
     type: Object,
     required: true,
@@ -18,38 +15,12 @@ const props = defineProps({
     required: true,
   },
 })
-
-const secteur = computed(() =>
-  donneesSecteurs.find((entree) => entree.id === props.secteurCourant.id),
-)
-
-const stationCourante = computed(() => secteur.value?.stationPrincipale ?? null)
-
-const estimationCargaison = computed(() => {
-  if (!stationCourante.value || !secteur.value) {
-    return {
-      valeurBrute: 0,
-      montantTaxe: 0,
-      valeurNette: 0,
-    }
-  }
-
-  return calculerValeurCargaisonPourStation(
-    props.ressources.minerais,
-    stationCourante.value,
-    secteur.value.securite,
-  )
-})
 </script>
 
 <template>
   <section class="panel">
     <h2>◈ Ressources</h2>
-    <p>Crédits : {{ ressources.credits }}</p>
     <p>Carburant : {{ ressources.carburant }} / {{ vaisseau.carburantMax }}</p>
-    <p>Soute : {{ vaisseau.soute }} / {{ vaisseau.souteMax }}</p>
-    <p>Valeur brute estimée : {{ estimationCargaison.valeurBrute }} crédits</p>
-    <p>Valeur nette estimée : {{ estimationCargaison.valeurNette }} crédits</p>
 
     <h3>Contenu minéral de la soute</h3>
     <ul class="resource-list resource-list-compact resource-list-mineraux">

--- a/src/game/donneesInitiales.js
+++ b/src/game/donneesInitiales.js
@@ -32,9 +32,16 @@ export function creerEtatInitialJeu() {
 
   return {
     meta: {
-      version: '0.3.14',
+      version: '0.3.15',
       auteur: 'Kaemyll',
       annee: 2026,
+    },
+
+    joueur: {
+      identite: 'À renseigner',
+      statut: 'Indépendant',
+      reputation: 'Inconnue',
+      fortune: 'En attente',
     },
 
     ressources: {


### PR DESCRIPTION
## Objectif
Introduire le panneau Pilote dans le cockpit pour amorcer l’identité du joueur, tout en allégeant et rationalisant la colonne gauche.

## Réalisations
- ajout du composant `PlayerPanel.vue`
- affichage du panneau Pilote en tête de colonne gauche
- ajout des données initiales `joueur`
- mise à jour de la version affichée en `v0.3.15`
- affichage de la fortune du joueur via les crédits disponibles
- remplacement du champ Statut par Réputation dans le panneau Pilote
- compactage visuel du panneau Pilote
- suppression des éléments de remplissage inutiles du panneau Pilote
- suppression des doublons dans le panneau Ressources :
  - retrait de la ligne Crédits
  - retrait de la ligne Soute
  - retrait des estimations de valeur brute / nette
- compactage du panneau Navigation :
  - destination sur une ligne plus dense
  - regroupement durée / coût carburant sur une seule ligne
- extraction du style du panneau Pilote dans `features/player.css`
- mise à jour du point d’entrée `main.css`

## Résultat
La colonne gauche est plus cohérente et plus lisible :
- Pilote
- Ressources
- Vaisseau
- Navigation

Le cockpit gagne en identité joueur sans surcharge visuelle.