### PR TITLE
v0.3.15-65 : feat(ui): afficher le statut economique et rendre l'identite du pilote editable

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -16,19 +16,19 @@ import HangarPanel from './components/HangarPanel.vue'
 import { recupererEtatJeu, reinitialiserEtatJeu } from './game/etatJeu'
 import { chargerJeu, sauvegarderJeu } from './game/systemeSauvegarde'
 import {
-  minerMineraiManuellement,
-  vendreTousLesMinerais,
-  acheterDroneMinier,
-  deployerDrones,
-  rappelerDrones,
+    minerMineraiManuellement,
+    vendreTousLesMinerais,
+    acheterDroneMinier,
+    deployerDrones,
+    rappelerDrones,
 } from './game/systemeMinage'
 import { acheterMineraiEnStation, vendreMineraiEnStation } from './game/systemeCommerce'
 import { ravitaillerCarburant } from './game/systemeRavitaillement'
 import { ameliorerVaisseau } from './game/systemeAmeliorations'
 import { reparerPartiellementVaisseauActif, reparerVaisseauActif } from './game/systemeReparation'
 import {
-  selectionnerDestination,
-  lancerVoyageVersDestinationSelectionnee,
+    selectionnerDestination,
+    lancerVoyageVersDestinationSelectionnee,
 } from './game/systemeNavigation'
 import { allerEnZoneOperations, retourALaStation } from './game/systemeLocalisation'
 import { scannerAmasMinier } from './game/systemeExploration'
@@ -39,217 +39,229 @@ import { acheterVaisseau, changerVaisseauActif } from './game/systemeVaisseaux'
 const etat = reactive({})
 
 function creerEtatUIInitial() {
-  return {
-    modeActif: 'station',
-    sousModeStation: 'commerce',
-  }
+    return {
+        modeActif: 'station',
+        sousModeStation: 'commerce',
+    }
 }
 
 const ui = reactive(creerEtatUIInitial())
 
 const secteurCourantComplet = computed(
-  () => donneesSecteurs.find((secteur) => secteur.id === etat.secteurCourant?.id) || null,
+    () => donneesSecteurs.find((secteur) => secteur.id === etat.secteurCourant?.id) || null,
 )
 
 const stationCourante = computed(() => secteurCourantComplet.value?.stationPrincipale ?? null)
 
 function normaliserSousModeStation() {
-  const services = stationCourante.value?.services
+    const services = stationCourante.value?.services
 
-  if (ui.sousModeStation === 'hangar') {
-    return
-  }
+    if (ui.sousModeStation === 'hangar') {
+        return
+    }
 
-  if (!services) {
+    if (!services) {
+        ui.sousModeStation = 'hangar'
+        return
+    }
+
+    if (ui.sousModeStation === 'commerce' && services.commerce) return
+    if (ui.sousModeStation === 'ravitaillement' && services.ravitaillement) return
+    if (ui.sousModeStation === 'atelier' && services.atelier) return
+
     ui.sousModeStation = 'hangar'
-    return
-  }
-
-  if (ui.sousModeStation === 'commerce' && services.commerce) return
-  if (ui.sousModeStation === 'ravitaillement' && services.ravitaillement) return
-  if (ui.sousModeStation === 'atelier' && services.atelier) return
-
-  ui.sousModeStation = 'hangar'
 }
 
 function synchroniserModeActifAvecPositionLocale() {
-  if (etat.positionLocale === 'station') {
-    ui.modeActif = 'station'
-    normaliserSousModeStation()
-    return
-  }
+    if (etat.positionLocale === 'station') {
+        ui.modeActif = 'station'
+        normaliserSousModeStation()
+        return
+    }
 
-  if (etat.positionLocale === 'operations') {
-    ui.modeActif = 'operations'
-  }
+    if (etat.positionLocale === 'operations') {
+        ui.modeActif = 'operations'
+    }
 }
 
 function synchroniserEtat() {
-  const etatCourant = structuredClone(recupererEtatJeu())
+    const etatCourant = structuredClone(recupererEtatJeu())
 
-  Object.keys(etat).forEach((cle) => {
-    delete etat[cle]
-  })
+    Object.keys(etat).forEach((cle) => {
+        delete etat[cle]
+    })
 
-  Object.assign(etat, etatCourant)
+    Object.assign(etat, etatCourant)
 
-  synchroniserModeActifAvecPositionLocale()
+    synchroniserModeActifAvecPositionLocale()
+}
+
+function gererRenommagePilote(nouvelleIdentite) {
+    const etatJeu = recupererEtatJeu()
+
+    if (!etatJeu.joueur) {
+        etatJeu.joueur = {}
+    }
+
+    etatJeu.joueur.identite = nouvelleIdentite
+    sauvegarderJeu()
+    synchroniserEtat()
 }
 
 function gererMinageManuel() {
-  minerMineraiManuellement()
-  sauvegarderJeu()
-  synchroniserEtat()
+    minerMineraiManuellement()
+    sauvegarderJeu()
+    synchroniserEtat()
 }
 
 function gererScanner() {
-  scannerAmasMinier()
-  sauvegarderJeu()
-  synchroniserEtat()
+    scannerAmasMinier()
+    sauvegarderJeu()
+    synchroniserEtat()
 }
 
 function gererVenteMinerai() {
-  vendreTousLesMinerais()
-  sauvegarderJeu()
-  synchroniserEtat()
+    vendreTousLesMinerais()
+    sauvegarderJeu()
+    synchroniserEtat()
 }
 
 function gererVenteBien(idBien, quantite = 1) {
-  vendreMineraiEnStation(idBien, quantite)
-  sauvegarderJeu()
-  synchroniserEtat()
+    vendreMineraiEnStation(idBien, quantite)
+    sauvegarderJeu()
+    synchroniserEtat()
 }
 
 function gererAchatBien(idBien, quantite = 1) {
-  acheterMineraiEnStation(idBien, quantite)
-  sauvegarderJeu()
-  synchroniserEtat()
+    acheterMineraiEnStation(idBien, quantite)
+    sauvegarderJeu()
+    synchroniserEtat()
 }
 
 function gererAchatDrone() {
-  acheterDroneMinier()
-  sauvegarderJeu()
-  synchroniserEtat()
+    acheterDroneMinier()
+    sauvegarderJeu()
+    synchroniserEtat()
 }
 
 function gererDeploiementDrones() {
-  deployerDrones()
-  sauvegarderJeu()
-  synchroniserEtat()
+    deployerDrones()
+    sauvegarderJeu()
+    synchroniserEtat()
 }
 
 function gererRappelDrones() {
-  rappelerDrones()
-  sauvegarderJeu()
-  synchroniserEtat()
+    rappelerDrones()
+    sauvegarderJeu()
+    synchroniserEtat()
 }
 
 function gererRavitaillement() {
-  ravitaillerCarburant()
-  sauvegarderJeu()
-  synchroniserEtat()
+    ravitaillerCarburant()
+    sauvegarderJeu()
+    synchroniserEtat()
 }
 
 function gererReparationVaisseau() {
-  reparerVaisseauActif()
-  sauvegarderJeu()
-  synchroniserEtat()
+    reparerVaisseauActif()
+    sauvegarderJeu()
+    synchroniserEtat()
 }
 
 function gererReparationPartielleVaisseau() {
-  reparerPartiellementVaisseauActif()
-  sauvegarderJeu()
-  synchroniserEtat()
+    reparerPartiellementVaisseauActif()
+    sauvegarderJeu()
+    synchroniserEtat()
 }
 
 function gererVoyage() {
-  lancerVoyageVersDestinationSelectionnee()
-  sauvegarderJeu()
-  synchroniserEtat()
+    lancerVoyageVersDestinationSelectionnee()
+    sauvegarderJeu()
+    synchroniserEtat()
 }
 
 function gererSelectionDestination(idDestination) {
-  selectionnerDestination(idDestination)
-  sauvegarderJeu()
-  synchroniserEtat()
+    selectionnerDestination(idDestination)
+    sauvegarderJeu()
+    synchroniserEtat()
 }
 
 function gererAmelioration(idAmelioration) {
-  ameliorerVaisseau(idAmelioration)
-  sauvegarderJeu()
-  synchroniserEtat()
+    ameliorerVaisseau(idAmelioration)
+    sauvegarderJeu()
+    synchroniserEtat()
 }
 
 function gererAllerOperations() {
-  const positionAvant = etat.positionLocale
+    const positionAvant = etat.positionLocale
 
-  allerEnZoneOperations()
-  sauvegarderJeu()
-  synchroniserEtat()
+    allerEnZoneOperations()
+    sauvegarderJeu()
+    synchroniserEtat()
 
-  if (positionAvant !== etat.positionLocale && etat.positionLocale === 'operations') {
-    ui.modeActif = 'operations'
-  }
+    if (positionAvant !== etat.positionLocale && etat.positionLocale === 'operations') {
+        ui.modeActif = 'operations'
+    }
 }
 
 function gererRetourStation() {
-  const positionAvant = etat.positionLocale
+    const positionAvant = etat.positionLocale
 
-  retourALaStation()
-  sauvegarderJeu()
-  synchroniserEtat()
+    retourALaStation()
+    sauvegarderJeu()
+    synchroniserEtat()
 
-  if (positionAvant !== etat.positionLocale && etat.positionLocale === 'station') {
-    ui.modeActif = 'station'
-    normaliserSousModeStation()
-  }
+    if (positionAvant !== etat.positionLocale && etat.positionLocale === 'station') {
+        ui.modeActif = 'station'
+        normaliserSousModeStation()
+    }
 }
 
 function gererChangerVaisseau(idVaisseau) {
-  changerVaisseauActif(idVaisseau)
-  sauvegarderJeu()
-  synchroniserEtat()
+    changerVaisseauActif(idVaisseau)
+    sauvegarderJeu()
+    synchroniserEtat()
 }
 
 function gererAcheterVaisseau(modeleId) {
-  acheterVaisseau(modeleId)
-  sauvegarderJeu()
-  synchroniserEtat()
+    acheterVaisseau(modeleId)
+    sauvegarderJeu()
+    synchroniserEtat()
 }
 
 function gererReinitialisation() {
-  reinitialiserEtatJeu()
-  Object.assign(ui, creerEtatUIInitial())
-  sauvegarderJeu()
-  synchroniserEtat()
+    reinitialiserEtatJeu()
+    Object.assign(ui, creerEtatUIInitial())
+    sauvegarderJeu()
+    synchroniserEtat()
 }
 
 function changerMode(mode) {
-  ui.modeActif = mode
-  if (mode === 'station') {
-    normaliserSousModeStation()
-  }
+    ui.modeActif = mode
+    if (mode === 'station') {
+        normaliserSousModeStation()
+    }
 }
 
 function changerSousModeStation(sousMode) {
-  ui.sousModeStation = sousMode
+    ui.sousModeStation = sousMode
 }
 
 onMounted(() => {
-  chargerJeu()
-  synchroniserEtat()
-  demarrerBoucleJeu(synchroniserEtat)
+    chargerJeu()
+    synchroniserEtat()
+    demarrerBoucleJeu(synchroniserEtat)
 })
 
 onUnmounted(() => {
-  arreterBoucleJeu()
+    arreterBoucleJeu()
 })
 </script>
 
 <template>
-  <main
-    class="app-shell"
-    v-if="
+    <main
+        class="app-shell"
+        v-if="
       etat.joueur &&
       etat.ressources &&
       etat.vaisseau &&
@@ -263,132 +275,136 @@ onUnmounted(() => {
       etat.exploration &&
       etat.assistance
     "
-  >
-    <header class="app-header">
-      <div class="header-top">
-        <div class="header-brand">
-          <h1 class="title-line">
-            <span class="title-icon">✦</span>
-            <span>New Horizon</span>
-            <span class="title-icon">✦</span>
-          </h1>
+    >
+        <header class="app-header">
+            <div class="header-top">
+                <div class="header-brand">
+                    <h1 class="title-line">
+                        <span class="title-icon">✦</span>
+                        <span>New Horizon</span>
+                        <span class="title-icon">✦</span>
+                    </h1>
 
-          <p class="subtitle">
-            Simulation spatiale incrémentale de prospection minière et de commerce
-          </p>
+                    <p class="subtitle">
+                        Simulation spatiale incrémentale de prospection minière et de commerce
+                    </p>
 
-          <p class="meta-line">
-            v{{ etat.meta?.version }} — {{ etat.meta?.auteur }} — {{ etat.meta?.annee }}
-          </p>
+                    <p class="meta-line">
+                        v{{ etat.meta?.version }} — {{ etat.meta?.auteur }} — {{ etat.meta?.annee }}
+                    </p>
+                </div>
+
+                <HeaderActions
+                    :mode-actif="ui.modeActif"
+                    @changer-mode="changerMode"
+                    @reinitialiser="gererReinitialisation"
+                />
+            </div>
+        </header>
+
+        <div class="app-main">
+            <section class="main-column main-column-left">
+                <PlayerPanel
+                    :player="etat.joueur"
+                    :credits="etat.ressources.credits"
+                    @renommer-pilote="gererRenommagePilote"
+                />
+
+                <ResourcePanel
+                    :ressources="etat.ressources"
+                    :vaisseau="etat.vaisseau"
+                    :secteur-courant="etat.secteurCourant"
+                />
+
+                <ShipPanel :vaisseau="etat.vaisseau" :industrie="etat.industrie" />
+
+                <NavigationPanel
+                    :secteur-courant-id="etat.secteurCourant.id"
+                    :navigation="etat.navigation"
+                    :position-locale="etat.positionLocale"
+                    @selectionner-destination="gererSelectionDestination"
+                    @voyager="gererVoyage"
+                />
+            </section>
+
+            <section class="main-column main-column-center">
+                <div class="center-top">
+                    <OperationPanel
+                        v-if="ui.modeActif === 'operations'"
+                        :ressources="etat.ressources"
+                        :vaisseau="etat.vaisseau"
+                        :industrie="etat.industrie"
+                        :navigation="etat.navigation"
+                        :position-locale="etat.positionLocale"
+                        :exploration="etat.exploration"
+                        :assistance="etat.assistance"
+                        @miner="gererMinageManuel"
+                        @scanner="gererScanner"
+                        @aller-operations="gererAllerOperations"
+                        @retour-station="gererRetourStation"
+                        @deployer-drones="gererDeploiementDrones"
+                        @rappeler-drones="gererRappelDrones"
+                    />
+
+                    <StationServicesPanel
+                        v-else-if="ui.modeActif === 'station'"
+                        :secteur-courant="etat.secteurCourant"
+                        :vaisseau="etat.vaisseau"
+                        :ressources="etat.ressources"
+                        :sous-mode-station="ui.sousModeStation"
+                        :position-locale="etat.positionLocale"
+                        :economie="etat.economie"
+                        @changer-sous-mode-station="changerSousModeStation"
+                        @vendre="gererVenteMinerai"
+                        @vendre-bien="gererVenteBien"
+                        @acheter-bien="gererAchatBien"
+                        @ravitailler="gererRavitaillement"
+                        @acheter-drone="gererAchatDrone"
+                        @reparer-vaisseau="gererReparationVaisseau"
+                        @reparer-partiellement-vaisseau="gererReparationPartielleVaisseau"
+                        @retour-station="gererRetourStation"
+                        @aller-operations="gererAllerOperations"
+                    >
+                        <template #hangar>
+                            <HangarPanel
+                                :secteur-courant="etat.secteurCourant"
+                                :vaisseau-actif-id="etat.vaisseauActifId"
+                                :vaisseaux-possedes="etat.vaisseauxPossedes"
+                                :vaisseau="etat.vaisseau"
+                                :ressources="etat.ressources"
+                                @changer-vaisseau="gererChangerVaisseau"
+                                @acheter-vaisseau="gererAcheterVaisseau"
+                            />
+                        </template>
+
+                        <template #atelier>
+                            <UpgradePanel
+                                :vaisseau="etat.vaisseau"
+                                :secteur-courant="etat.secteurCourant"
+                                @ameliorer="gererAmelioration"
+                            />
+                        </template>
+                    </StationServicesPanel>
+
+                    <NavigationPanel
+                        v-else-if="ui.modeActif === 'navigation'"
+                        :secteur-courant-id="etat.secteurCourant.id"
+                        :navigation="etat.navigation"
+                        :position-locale="etat.positionLocale"
+                        @selectionner-destination="gererSelectionDestination"
+                        @voyager="gererVoyage"
+                    />
+                </div>
+
+                <section class="journal-panel">
+                    <LogPanel :entrees="etat.journal" />
+                </section>
+            </section>
+
+            <aside class="right-aside">
+                <SectorPanel :secteur-courant="etat.secteurCourant" />
+                <StationPanel :secteur-courant="etat.secteurCourant" />
+            </aside>
         </div>
-
-        <HeaderActions
-          :mode-actif="ui.modeActif"
-          @changer-mode="changerMode"
-          @reinitialiser="gererReinitialisation"
-        />
-      </div>
-    </header>
-
-    <div class="app-main">
-      <section class="main-column main-column-left">
-        <PlayerPanel :player="etat.joueur" :credits="etat.ressources.credits" />
-
-        <ResourcePanel
-          :ressources="etat.ressources"
-          :vaisseau="etat.vaisseau"
-          :secteur-courant="etat.secteurCourant"
-        />
-
-        <ShipPanel :vaisseau="etat.vaisseau" :industrie="etat.industrie" />
-
-        <NavigationPanel
-          :secteur-courant-id="etat.secteurCourant.id"
-          :navigation="etat.navigation"
-          :position-locale="etat.positionLocale"
-          @selectionner-destination="gererSelectionDestination"
-          @voyager="gererVoyage"
-        />
-      </section>
-
-      <section class="main-column main-column-center">
-        <div class="center-top">
-          <OperationPanel
-            v-if="ui.modeActif === 'operations'"
-            :ressources="etat.ressources"
-            :vaisseau="etat.vaisseau"
-            :industrie="etat.industrie"
-            :navigation="etat.navigation"
-            :position-locale="etat.positionLocale"
-            :exploration="etat.exploration"
-            :assistance="etat.assistance"
-            @miner="gererMinageManuel"
-            @scanner="gererScanner"
-            @aller-operations="gererAllerOperations"
-            @retour-station="gererRetourStation"
-            @deployer-drones="gererDeploiementDrones"
-            @rappeler-drones="gererRappelDrones"
-          />
-
-          <StationServicesPanel
-            v-else-if="ui.modeActif === 'station'"
-            :secteur-courant="etat.secteurCourant"
-            :vaisseau="etat.vaisseau"
-            :ressources="etat.ressources"
-            :sous-mode-station="ui.sousModeStation"
-            :position-locale="etat.positionLocale"
-            :economie="etat.economie"
-            @changer-sous-mode-station="changerSousModeStation"
-            @vendre="gererVenteMinerai"
-            @vendre-bien="gererVenteBien"
-            @acheter-bien="gererAchatBien"
-            @ravitailler="gererRavitaillement"
-            @acheter-drone="gererAchatDrone"
-            @reparer-vaisseau="gererReparationVaisseau"
-            @reparer-partiellement-vaisseau="gererReparationPartielleVaisseau"
-            @retour-station="gererRetourStation"
-            @aller-operations="gererAllerOperations"
-          >
-            <template #hangar>
-              <HangarPanel
-                :secteur-courant="etat.secteurCourant"
-                :vaisseau-actif-id="etat.vaisseauActifId"
-                :vaisseaux-possedes="etat.vaisseauxPossedes"
-                :vaisseau="etat.vaisseau"
-                :ressources="etat.ressources"
-                @changer-vaisseau="gererChangerVaisseau"
-                @acheter-vaisseau="gererAcheterVaisseau"
-              />
-            </template>
-
-            <template #atelier>
-              <UpgradePanel
-                :vaisseau="etat.vaisseau"
-                :secteur-courant="etat.secteurCourant"
-                @ameliorer="gererAmelioration"
-              />
-            </template>
-          </StationServicesPanel>
-
-          <NavigationPanel
-            v-else-if="ui.modeActif === 'navigation'"
-            :secteur-courant-id="etat.secteurCourant.id"
-            :navigation="etat.navigation"
-            :position-locale="etat.positionLocale"
-            @selectionner-destination="gererSelectionDestination"
-            @voyager="gererVoyage"
-          />
-        </div>
-
-        <section class="journal-panel">
-          <LogPanel :entrees="etat.journal" />
-        </section>
-      </section>
-
-      <aside class="right-aside">
-        <SectorPanel :secteur-courant="etat.secteurCourant" />
-        <StationPanel :secteur-courant="etat.secteurCourant" />
-      </aside>
-    </div>
-  </main>
+    </main>
 </template>

--- a/src/assets/styles/features/player.css
+++ b/src/assets/styles/features/player.css
@@ -18,8 +18,8 @@
   position: absolute;
   inset: 0;
   background:
-    linear-gradient(135deg, rgba(125, 184, 255, 0.05), transparent 45%),
-    linear-gradient(180deg, rgba(255, 255, 255, 0.015), transparent 55%);
+          linear-gradient(135deg, rgba(125, 184, 255, 0.05), transparent 45%),
+          linear-gradient(180deg, rgba(255, 255, 255, 0.015), transparent 55%);
   pointer-events: none;
 }
 
@@ -38,7 +38,9 @@
 }
 
 .player-panel-badge {
-  flex: 0 0 auto;
+  flex: 0 1 auto;
+  min-width: 0;
+  max-width: 58%;
   padding: 2px 7px;
   border: 1px solid rgba(125, 184, 255, 0.18);
   border-radius: 999px;
@@ -47,6 +49,9 @@
   letter-spacing: 0.04em;
   text-transform: uppercase;
   opacity: 0.92;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .player-panel-grid {
@@ -78,4 +83,51 @@
   font-size: 0.84rem;
   line-height: 1.05;
   color: #d8e7f7;
+}
+
+.player-panel-line-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.player-panel-edit-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  padding: 0;
+  border: 1px solid rgba(125, 184, 255, 0.16);
+  border-radius: 999px;
+  background: rgba(125, 184, 255, 0.06);
+  color: #d8e7f7;
+  font-size: 0.68rem;
+  line-height: 1;
+  cursor: pointer;
+  transition:
+          background var(--nh-motion-duration-fast) var(--nh-motion-ease-standard),
+          border-color var(--nh-motion-duration-fast) var(--nh-motion-ease-standard),
+          opacity var(--nh-motion-duration-fast) var(--nh-motion-ease-standard);
+}
+
+.player-panel-edit-button:hover {
+  background: rgba(125, 184, 255, 0.12);
+  border-color: rgba(125, 184, 255, 0.28);
+}
+
+.player-panel-edit-row {
+  margin-top: 2px;
+}
+
+.player-panel-input {
+  width: 100%;
+  padding: 0.34rem 0.45rem;
+  border: 1px solid #3c536b;
+  border-radius: 6px;
+  background: #0f1822;
+  color: #eef5fb;
+  font-size: 0.82rem;
+  line-height: 1.05;
 }

--- a/src/components/PlayerPanel.vue
+++ b/src/components/PlayerPanel.vue
@@ -1,45 +1,120 @@
 <script setup>
-defineProps({
-  player: {
-    type: Object,
-    default: () => ({}),
-  },
-  credits: {
-    type: Number,
-    default: 0,
-  },
+import { computed, ref, watch } from 'vue'
+
+const props = defineProps({
+    player: {
+        type: Object,
+        default: () => ({}),
+    },
+    credits: {
+        type: Number,
+        default: 0,
+    },
 })
+
+const emit = defineEmits(['renommer-pilote'])
+
+const modeEditionNom = ref(false)
+const identiteBrouillon = ref('')
+
+const identiteAffichee = computed(() => props.player?.identite || 'Sans indicatif')
+
+const statutEconomique = computed(() => {
+    const credits = Number(props.credits) || 0
+
+    if (credits >= 20000000) return 'VII — Consortium privé'
+    if (credits >= 5000000) return 'VI — Armateur privé'
+    if (credits >= 1000000) return 'V — Magnat local'
+    if (credits >= 250000) return 'IV — Exploitant'
+    if (credits >= 50000) return 'III — Opérateur'
+    if (credits >= 10000) return 'II — Freelancer'
+    return 'I — Indépendant'
+})
+
+const reputationAffichee = computed(() => props.player?.reputation || 'I — Neutre')
+
+watch(
+    () => props.player?.identite,
+    (nouvelleIdentite) => {
+        identiteBrouillon.value = nouvelleIdentite || 'Sans indicatif'
+    },
+    { immediate: true },
+)
+
+function activerEditionNom() {
+    identiteBrouillon.value = identiteAffichee.value
+    modeEditionNom.value = true
+}
+
+function validerEditionNom() {
+    const valeurNettoyee = (identiteBrouillon.value || '').trim()
+    emit('renommer-pilote', valeurNettoyee || 'Sans indicatif')
+    modeEditionNom.value = false
+}
+
+function annulerEditionNom() {
+    identiteBrouillon.value = identiteAffichee.value
+    modeEditionNom.value = false
+}
 </script>
 
 <template>
-  <section class="panel player-panel">
-    <div class="player-panel-header">
-      <h2>◉ Pilote</h2>
+    <section class="panel player-panel">
+        <div class="player-panel-header">
+            <h2>◉ Pilote</h2>
 
-      <span class="player-panel-badge">
-        {{ player?.statut || 'Indépendant' }}
+            <span class="player-panel-badge">
+        {{ statutEconomique }}
       </span>
-    </div>
+        </div>
 
-    <div class="player-panel-grid">
-      <div class="player-panel-card">
-        <span class="player-panel-label">Identité</span>
-        <strong class="player-panel-value">
-          {{ player?.identite || 'À renseigner' }}
-        </strong>
-      </div>
+        <div class="player-panel-grid">
+            <div class="player-panel-card">
+                <div class="player-panel-line-header">
+                    <span class="player-panel-label">Identité</span>
 
-      <div class="player-panel-card">
-        <span class="player-panel-label">Réputation</span>
-        <strong class="player-panel-value">
-          {{ player?.reputation || 'Inconnue' }}
-        </strong>
-      </div>
+                    <button
+                        v-if="!modeEditionNom"
+                        type="button"
+                        class="player-panel-edit-button"
+                        @click="activerEditionNom"
+                        aria-label="Modifier l'identité du pilote"
+                        title="Modifier l'identité du pilote"
+                    >
+                        ✎
+                    </button>
+                </div>
 
-      <div class="player-panel-card">
-        <span class="player-panel-label">Fortune</span>
-        <strong class="player-panel-value"> {{ credits }} crédits </strong>
-      </div>
-    </div>
-  </section>
+                <div v-if="modeEditionNom" class="player-panel-edit-row">
+                    <input
+                        v-model="identiteBrouillon"
+                        type="text"
+                        maxlength="40"
+                        class="player-panel-input"
+                        @keydown.enter.prevent="validerEditionNom"
+                        @keydown.esc.prevent="annulerEditionNom"
+                        @blur="validerEditionNom"
+                    />
+                </div>
+
+                <strong v-else class="player-panel-value">
+                    {{ identiteAffichee }}
+                </strong>
+            </div>
+
+            <div class="player-panel-card">
+                <span class="player-panel-label">Réputation</span>
+                <strong class="player-panel-value">
+                    {{ reputationAffichee }}
+                </strong>
+            </div>
+
+            <div class="player-panel-card">
+                <span class="player-panel-label">Fortune</span>
+                <strong class="player-panel-value">
+                    {{ credits }} crédits
+                </strong>
+            </div>
+        </div>
+    </section>
 </template>

--- a/src/game/donneesInitiales.js
+++ b/src/game/donneesInitiales.js
@@ -38,10 +38,8 @@ export function creerEtatInitialJeu() {
     },
 
     joueur: {
-      identite: 'À renseigner',
-      statut: 'Indépendant',
-      reputation: 'Inconnue',
-      fortune: 'En attente',
+      identite: 'Sans indicatif',
+      reputation: 'I — Neutre',
     },
 
     ressources: {


### PR DESCRIPTION
## Objectif
Rendre le panneau Pilote réellement informatif et interactif dans le cadre de la v0.3.15.

## Réalisations
- affichage du statut économique du pilote dans le badge du panneau
- calcul du statut à partir de la fortune du joueur
- ajout d’un septième rang économique pour respecter la progression validée
- affichage en temps réel de la fortune à partir des crédits du joueur
- affichage de la réputation dans le panneau Pilote
- initialisation de l’identité par défaut à `Sans indicatif`
- ajout d’une édition inline de l’identité via une icône crayon
- sauvegarde du renommage du pilote dans l’état du jeu

## Rangs économiques intégrés
- I — Indépendant
- II — Freelancer
- III — Opérateur
- IV — Exploitant
- V — Magnat local
- VI — Armateur privé
- VII — Consortium privé

## Résultat
Le panneau Pilote n’est plus seulement structurel :
- il reflète la richesse réelle du joueur
- il expose une identité modifiable
- il prépare proprement les futures mécaniques de réputation et de progression sociale