### PR TITLE
Feature/v0.3.15 122 carburant jauge vaisseau

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ New Horizon repose sur quelques principes simples :
 
 ## 🚀 État actuel du projet
 
-**Version actuelle : v0.3.14**
+**Version actuelle : v0.3.15**
 
 ### Fonctionnalités principales
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -346,7 +346,11 @@ onUnmounted(() => {
                     :secteur-courant="etat.secteurCourant"
                 />
 
-                <ShipPanel :vaisseau="etat.vaisseau" :industrie="etat.industrie" />
+                <ShipPanel
+                    :vaisseau="etat.vaisseau"
+                    :industrie="etat.industrie"
+                    :ressources="etat.ressources"
+                />
 
                 <NavigationPanel
                     :secteur-courant-id="etat.secteurCourant.id"

--- a/src/App.vue
+++ b/src/App.vue
@@ -16,19 +16,19 @@ import HangarPanel from './components/HangarPanel.vue'
 import { recupererEtatJeu, reinitialiserEtatJeu } from './game/etatJeu'
 import { chargerJeu, sauvegarderJeu } from './game/systemeSauvegarde'
 import {
-  minerMineraiManuellement,
-  vendreTousLesMinerais,
-  acheterDroneMinier,
-  deployerDrones,
-  rappelerDrones,
+    minerMineraiManuellement,
+    vendreTousLesMinerais,
+    acheterDroneMinier,
+    deployerDrones,
+    rappelerDrones,
 } from './game/systemeMinage'
 import { acheterMineraiEnStation, vendreMineraiEnStation } from './game/systemeCommerce'
 import { ravitaillerCarburant } from './game/systemeRavitaillement'
 import { ameliorerVaisseau } from './game/systemeAmeliorations'
 import { reparerPartiellementVaisseauActif, reparerVaisseauActif } from './game/systemeReparation'
 import {
-  selectionnerDestination,
-  lancerVoyageVersDestinationSelectionnee,
+    selectionnerDestination,
+    lancerVoyageVersDestinationSelectionnee,
 } from './game/systemeNavigation'
 import { allerEnZoneOperations, retourALaStation } from './game/systemeLocalisation'
 import { scannerAmasMinier } from './game/systemeExploration'
@@ -39,217 +39,229 @@ import { acheterVaisseau, changerVaisseauActif } from './game/systemeVaisseaux'
 const etat = reactive({})
 
 function creerEtatUIInitial() {
-  return {
-    modeActif: 'station',
-    sousModeStation: 'commerce',
-  }
+    return {
+        modeActif: 'station',
+        sousModeStation: 'commerce',
+    }
 }
 
 const ui = reactive(creerEtatUIInitial())
 
 const secteurCourantComplet = computed(
-  () => donneesSecteurs.find((secteur) => secteur.id === etat.secteurCourant?.id) || null,
+    () => donneesSecteurs.find((secteur) => secteur.id === etat.secteurCourant?.id) || null,
 )
 
 const stationCourante = computed(() => secteurCourantComplet.value?.stationPrincipale ?? null)
 
 function normaliserSousModeStation() {
-  const services = stationCourante.value?.services
+    const services = stationCourante.value?.services
 
-  if (ui.sousModeStation === 'hangar') {
-    return
-  }
+    if (ui.sousModeStation === 'hangar') {
+        return
+    }
 
-  if (!services) {
+    if (!services) {
+        ui.sousModeStation = 'hangar'
+        return
+    }
+
+    if (ui.sousModeStation === 'commerce' && services.commerce) return
+    if (ui.sousModeStation === 'ravitaillement' && services.ravitaillement) return
+    if (ui.sousModeStation === 'atelier' && services.atelier) return
+
     ui.sousModeStation = 'hangar'
-    return
-  }
-
-  if (ui.sousModeStation === 'commerce' && services.commerce) return
-  if (ui.sousModeStation === 'ravitaillement' && services.ravitaillement) return
-  if (ui.sousModeStation === 'atelier' && services.atelier) return
-
-  ui.sousModeStation = 'hangar'
 }
 
 function synchroniserModeActifAvecPositionLocale() {
-  if (etat.positionLocale === 'station') {
-    ui.modeActif = 'station'
-    normaliserSousModeStation()
-    return
-  }
+    if (etat.positionLocale === 'station') {
+        ui.modeActif = 'station'
+        normaliserSousModeStation()
+        return
+    }
 
-  if (etat.positionLocale === 'operations') {
-    ui.modeActif = 'operations'
-  }
+    if (etat.positionLocale === 'operations') {
+        ui.modeActif = 'operations'
+    }
 }
 
 function synchroniserEtat() {
-  const etatCourant = structuredClone(recupererEtatJeu())
+    const etatCourant = structuredClone(recupererEtatJeu())
 
-  Object.keys(etat).forEach((cle) => {
-    delete etat[cle]
-  })
+    Object.keys(etat).forEach((cle) => {
+        delete etat[cle]
+    })
 
-  Object.assign(etat, etatCourant)
+    Object.assign(etat, etatCourant)
 
-  synchroniserModeActifAvecPositionLocale()
+    synchroniserModeActifAvecPositionLocale()
+}
+
+function gererRenommagePilote(nouvelleIdentite) {
+    const etatJeu = recupererEtatJeu()
+
+    if (!etatJeu.joueur) {
+        etatJeu.joueur = {}
+    }
+
+    etatJeu.joueur.identite = nouvelleIdentite
+    sauvegarderJeu()
+    synchroniserEtat()
 }
 
 function gererMinageManuel() {
-  minerMineraiManuellement()
-  sauvegarderJeu()
-  synchroniserEtat()
+    minerMineraiManuellement()
+    sauvegarderJeu()
+    synchroniserEtat()
 }
 
 function gererScanner() {
-  scannerAmasMinier()
-  sauvegarderJeu()
-  synchroniserEtat()
+    scannerAmasMinier()
+    sauvegarderJeu()
+    synchroniserEtat()
 }
 
 function gererVenteMinerai() {
-  vendreTousLesMinerais()
-  sauvegarderJeu()
-  synchroniserEtat()
+    vendreTousLesMinerais()
+    sauvegarderJeu()
+    synchroniserEtat()
 }
 
 function gererVenteBien(idBien, quantite = 1) {
-  vendreMineraiEnStation(idBien, quantite)
-  sauvegarderJeu()
-  synchroniserEtat()
+    vendreMineraiEnStation(idBien, quantite)
+    sauvegarderJeu()
+    synchroniserEtat()
 }
 
 function gererAchatBien(idBien, quantite = 1) {
-  acheterMineraiEnStation(idBien, quantite)
-  sauvegarderJeu()
-  synchroniserEtat()
+    acheterMineraiEnStation(idBien, quantite)
+    sauvegarderJeu()
+    synchroniserEtat()
 }
 
 function gererAchatDrone() {
-  acheterDroneMinier()
-  sauvegarderJeu()
-  synchroniserEtat()
+    acheterDroneMinier()
+    sauvegarderJeu()
+    synchroniserEtat()
 }
 
 function gererDeploiementDrones() {
-  deployerDrones()
-  sauvegarderJeu()
-  synchroniserEtat()
+    deployerDrones()
+    sauvegarderJeu()
+    synchroniserEtat()
 }
 
 function gererRappelDrones() {
-  rappelerDrones()
-  sauvegarderJeu()
-  synchroniserEtat()
+    rappelerDrones()
+    sauvegarderJeu()
+    synchroniserEtat()
 }
 
 function gererRavitaillement() {
-  ravitaillerCarburant()
-  sauvegarderJeu()
-  synchroniserEtat()
+    ravitaillerCarburant()
+    sauvegarderJeu()
+    synchroniserEtat()
 }
 
 function gererReparationVaisseau() {
-  reparerVaisseauActif()
-  sauvegarderJeu()
-  synchroniserEtat()
+    reparerVaisseauActif()
+    sauvegarderJeu()
+    synchroniserEtat()
 }
 
 function gererReparationPartielleVaisseau() {
-  reparerPartiellementVaisseauActif()
-  sauvegarderJeu()
-  synchroniserEtat()
+    reparerPartiellementVaisseauActif()
+    sauvegarderJeu()
+    synchroniserEtat()
 }
 
 function gererVoyage() {
-  lancerVoyageVersDestinationSelectionnee()
-  sauvegarderJeu()
-  synchroniserEtat()
+    lancerVoyageVersDestinationSelectionnee()
+    sauvegarderJeu()
+    synchroniserEtat()
 }
 
 function gererSelectionDestination(idDestination) {
-  selectionnerDestination(idDestination)
-  sauvegarderJeu()
-  synchroniserEtat()
+    selectionnerDestination(idDestination)
+    sauvegarderJeu()
+    synchroniserEtat()
 }
 
 function gererAmelioration(idAmelioration) {
-  ameliorerVaisseau(idAmelioration)
-  sauvegarderJeu()
-  synchroniserEtat()
+    ameliorerVaisseau(idAmelioration)
+    sauvegarderJeu()
+    synchroniserEtat()
 }
 
 function gererAllerOperations() {
-  const positionAvant = etat.positionLocale
+    const positionAvant = etat.positionLocale
 
-  allerEnZoneOperations()
-  sauvegarderJeu()
-  synchroniserEtat()
+    allerEnZoneOperations()
+    sauvegarderJeu()
+    synchroniserEtat()
 
-  if (positionAvant !== etat.positionLocale && etat.positionLocale === 'operations') {
-    ui.modeActif = 'operations'
-  }
+    if (positionAvant !== etat.positionLocale && etat.positionLocale === 'operations') {
+        ui.modeActif = 'operations'
+    }
 }
 
 function gererRetourStation() {
-  const positionAvant = etat.positionLocale
+    const positionAvant = etat.positionLocale
 
-  retourALaStation()
-  sauvegarderJeu()
-  synchroniserEtat()
+    retourALaStation()
+    sauvegarderJeu()
+    synchroniserEtat()
 
-  if (positionAvant !== etat.positionLocale && etat.positionLocale === 'station') {
-    ui.modeActif = 'station'
-    normaliserSousModeStation()
-  }
+    if (positionAvant !== etat.positionLocale && etat.positionLocale === 'station') {
+        ui.modeActif = 'station'
+        normaliserSousModeStation()
+    }
 }
 
 function gererChangerVaisseau(idVaisseau) {
-  changerVaisseauActif(idVaisseau)
-  sauvegarderJeu()
-  synchroniserEtat()
+    changerVaisseauActif(idVaisseau)
+    sauvegarderJeu()
+    synchroniserEtat()
 }
 
 function gererAcheterVaisseau(modeleId) {
-  acheterVaisseau(modeleId)
-  sauvegarderJeu()
-  synchroniserEtat()
+    acheterVaisseau(modeleId)
+    sauvegarderJeu()
+    synchroniserEtat()
 }
 
 function gererReinitialisation() {
-  reinitialiserEtatJeu()
-  Object.assign(ui, creerEtatUIInitial())
-  sauvegarderJeu()
-  synchroniserEtat()
+    reinitialiserEtatJeu()
+    Object.assign(ui, creerEtatUIInitial())
+    sauvegarderJeu()
+    synchroniserEtat()
 }
 
 function changerMode(mode) {
-  ui.modeActif = mode
-  if (mode === 'station') {
-    normaliserSousModeStation()
-  }
+    ui.modeActif = mode
+    if (mode === 'station') {
+        normaliserSousModeStation()
+    }
 }
 
 function changerSousModeStation(sousMode) {
-  ui.sousModeStation = sousMode
+    ui.sousModeStation = sousMode
 }
 
 onMounted(() => {
-  chargerJeu()
-  synchroniserEtat()
-  demarrerBoucleJeu(synchroniserEtat)
+    chargerJeu()
+    synchroniserEtat()
+    demarrerBoucleJeu(synchroniserEtat)
 })
 
 onUnmounted(() => {
-  arreterBoucleJeu()
+    arreterBoucleJeu()
 })
 </script>
 
 <template>
-  <main
-    class="app-shell"
-    v-if="
+    <main
+        class="app-shell"
+        v-if="
       etat.joueur &&
       etat.ressources &&
       etat.vaisseau &&
@@ -263,132 +275,136 @@ onUnmounted(() => {
       etat.exploration &&
       etat.assistance
     "
-  >
-    <header class="app-header">
-      <div class="header-top">
-        <div class="header-brand">
-          <h1 class="title-line">
-            <span class="title-icon">✦</span>
-            <span>New Horizon</span>
-            <span class="title-icon">✦</span>
-          </h1>
+    >
+        <header class="app-header">
+            <div class="header-top">
+                <div class="header-brand">
+                    <h1 class="title-line">
+                        <span class="title-icon">✦</span>
+                        <span>New Horizon</span>
+                        <span class="title-icon">✦</span>
+                    </h1>
 
-          <p class="subtitle">
-            Simulation spatiale incrémentale de prospection minière et de commerce
-          </p>
+                    <p class="subtitle">
+                        Simulation spatiale incrémentale de prospection minière et de commerce
+                    </p>
 
-          <p class="meta-line">
-            v{{ etat.meta?.version }} — {{ etat.meta?.auteur }} — {{ etat.meta?.annee }}
-          </p>
+                    <p class="meta-line">
+                        v{{ etat.meta?.version }} — {{ etat.meta?.auteur }} — {{ etat.meta?.annee }}
+                    </p>
+                </div>
+
+                <HeaderActions
+                    :mode-actif="ui.modeActif"
+                    @changer-mode="changerMode"
+                    @reinitialiser="gererReinitialisation"
+                />
+            </div>
+        </header>
+
+        <div class="app-main">
+            <section class="main-column main-column-left">
+                <PlayerPanel
+                    :player="etat.joueur"
+                    :credits="etat.ressources.credits"
+                    @renommer-pilote="gererRenommagePilote"
+                />
+
+                <ResourcePanel
+                    :ressources="etat.ressources"
+                    :vaisseau="etat.vaisseau"
+                    :secteur-courant="etat.secteurCourant"
+                />
+
+                <ShipPanel :vaisseau="etat.vaisseau" :industrie="etat.industrie" />
+
+                <NavigationPanel
+                    :secteur-courant-id="etat.secteurCourant.id"
+                    :navigation="etat.navigation"
+                    :position-locale="etat.positionLocale"
+                    @selectionner-destination="gererSelectionDestination"
+                    @voyager="gererVoyage"
+                />
+            </section>
+
+            <section class="main-column main-column-center">
+                <div class="center-top">
+                    <OperationPanel
+                        v-if="ui.modeActif === 'operations'"
+                        :ressources="etat.ressources"
+                        :vaisseau="etat.vaisseau"
+                        :industrie="etat.industrie"
+                        :navigation="etat.navigation"
+                        :position-locale="etat.positionLocale"
+                        :exploration="etat.exploration"
+                        :assistance="etat.assistance"
+                        @miner="gererMinageManuel"
+                        @scanner="gererScanner"
+                        @aller-operations="gererAllerOperations"
+                        @retour-station="gererRetourStation"
+                        @deployer-drones="gererDeploiementDrones"
+                        @rappeler-drones="gererRappelDrones"
+                    />
+
+                    <StationServicesPanel
+                        v-else-if="ui.modeActif === 'station'"
+                        :secteur-courant="etat.secteurCourant"
+                        :vaisseau="etat.vaisseau"
+                        :ressources="etat.ressources"
+                        :sous-mode-station="ui.sousModeStation"
+                        :position-locale="etat.positionLocale"
+                        :economie="etat.economie"
+                        @changer-sous-mode-station="changerSousModeStation"
+                        @vendre="gererVenteMinerai"
+                        @vendre-bien="gererVenteBien"
+                        @acheter-bien="gererAchatBien"
+                        @ravitailler="gererRavitaillement"
+                        @acheter-drone="gererAchatDrone"
+                        @reparer-vaisseau="gererReparationVaisseau"
+                        @reparer-partiellement-vaisseau="gererReparationPartielleVaisseau"
+                        @retour-station="gererRetourStation"
+                        @aller-operations="gererAllerOperations"
+                    >
+                        <template #hangar>
+                            <HangarPanel
+                                :secteur-courant="etat.secteurCourant"
+                                :vaisseau-actif-id="etat.vaisseauActifId"
+                                :vaisseaux-possedes="etat.vaisseauxPossedes"
+                                :vaisseau="etat.vaisseau"
+                                :ressources="etat.ressources"
+                                @changer-vaisseau="gererChangerVaisseau"
+                                @acheter-vaisseau="gererAcheterVaisseau"
+                            />
+                        </template>
+
+                        <template #atelier>
+                            <UpgradePanel
+                                :vaisseau="etat.vaisseau"
+                                :secteur-courant="etat.secteurCourant"
+                                @ameliorer="gererAmelioration"
+                            />
+                        </template>
+                    </StationServicesPanel>
+
+                    <NavigationPanel
+                        v-else-if="ui.modeActif === 'navigation'"
+                        :secteur-courant-id="etat.secteurCourant.id"
+                        :navigation="etat.navigation"
+                        :position-locale="etat.positionLocale"
+                        @selectionner-destination="gererSelectionDestination"
+                        @voyager="gererVoyage"
+                    />
+                </div>
+
+                <section class="journal-panel">
+                    <LogPanel :entrees="etat.journal" />
+                </section>
+            </section>
+
+            <aside class="right-aside">
+                <SectorPanel :secteur-courant="etat.secteurCourant" />
+                <StationPanel :secteur-courant="etat.secteurCourant" />
+            </aside>
         </div>
-
-        <HeaderActions
-          :mode-actif="ui.modeActif"
-          @changer-mode="changerMode"
-          @reinitialiser="gererReinitialisation"
-        />
-      </div>
-    </header>
-
-    <div class="app-main">
-      <section class="main-column main-column-left">
-        <PlayerPanel :player="etat.joueur" :credits="etat.ressources.credits" />
-
-        <ResourcePanel
-          :ressources="etat.ressources"
-          :vaisseau="etat.vaisseau"
-          :secteur-courant="etat.secteurCourant"
-        />
-
-        <ShipPanel :vaisseau="etat.vaisseau" :industrie="etat.industrie" />
-
-        <NavigationPanel
-          :secteur-courant-id="etat.secteurCourant.id"
-          :navigation="etat.navigation"
-          :position-locale="etat.positionLocale"
-          @selectionner-destination="gererSelectionDestination"
-          @voyager="gererVoyage"
-        />
-      </section>
-
-      <section class="main-column main-column-center">
-        <div class="center-top">
-          <OperationPanel
-            v-if="ui.modeActif === 'operations'"
-            :ressources="etat.ressources"
-            :vaisseau="etat.vaisseau"
-            :industrie="etat.industrie"
-            :navigation="etat.navigation"
-            :position-locale="etat.positionLocale"
-            :exploration="etat.exploration"
-            :assistance="etat.assistance"
-            @miner="gererMinageManuel"
-            @scanner="gererScanner"
-            @aller-operations="gererAllerOperations"
-            @retour-station="gererRetourStation"
-            @deployer-drones="gererDeploiementDrones"
-            @rappeler-drones="gererRappelDrones"
-          />
-
-          <StationServicesPanel
-            v-else-if="ui.modeActif === 'station'"
-            :secteur-courant="etat.secteurCourant"
-            :vaisseau="etat.vaisseau"
-            :ressources="etat.ressources"
-            :sous-mode-station="ui.sousModeStation"
-            :position-locale="etat.positionLocale"
-            :economie="etat.economie"
-            @changer-sous-mode-station="changerSousModeStation"
-            @vendre="gererVenteMinerai"
-            @vendre-bien="gererVenteBien"
-            @acheter-bien="gererAchatBien"
-            @ravitailler="gererRavitaillement"
-            @acheter-drone="gererAchatDrone"
-            @reparer-vaisseau="gererReparationVaisseau"
-            @reparer-partiellement-vaisseau="gererReparationPartielleVaisseau"
-            @retour-station="gererRetourStation"
-            @aller-operations="gererAllerOperations"
-          >
-            <template #hangar>
-              <HangarPanel
-                :secteur-courant="etat.secteurCourant"
-                :vaisseau-actif-id="etat.vaisseauActifId"
-                :vaisseaux-possedes="etat.vaisseauxPossedes"
-                :vaisseau="etat.vaisseau"
-                :ressources="etat.ressources"
-                @changer-vaisseau="gererChangerVaisseau"
-                @acheter-vaisseau="gererAcheterVaisseau"
-              />
-            </template>
-
-            <template #atelier>
-              <UpgradePanel
-                :vaisseau="etat.vaisseau"
-                :secteur-courant="etat.secteurCourant"
-                @ameliorer="gererAmelioration"
-              />
-            </template>
-          </StationServicesPanel>
-
-          <NavigationPanel
-            v-else-if="ui.modeActif === 'navigation'"
-            :secteur-courant-id="etat.secteurCourant.id"
-            :navigation="etat.navigation"
-            :position-locale="etat.positionLocale"
-            @selectionner-destination="gererSelectionDestination"
-            @voyager="gererVoyage"
-          />
-        </div>
-
-        <section class="journal-panel">
-          <LogPanel :entrees="etat.journal" />
-        </section>
-      </section>
-
-      <aside class="right-aside">
-        <SectorPanel :secteur-courant="etat.secteurCourant" />
-        <StationPanel :secteur-courant="etat.secteurCourant" />
-      </aside>
-    </div>
-  </main>
+    </main>
 </template>

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { computed, onMounted, onUnmounted, reactive } from 'vue'
+import PlayerPanel from './components/PlayerPanel.vue'
 import ResourcePanel from './components/ResourcePanel.vue'
 import ShipPanel from './components/ShipPanel.vue'
 import SectorPanel from './components/SectorPanel.vue'
@@ -15,22 +16,19 @@ import HangarPanel from './components/HangarPanel.vue'
 import { recupererEtatJeu, reinitialiserEtatJeu } from './game/etatJeu'
 import { chargerJeu, sauvegarderJeu } from './game/systemeSauvegarde'
 import {
-    minerMineraiManuellement,
-    vendreTousLesMinerais,
-    acheterDroneMinier,
-    deployerDrones,
-    rappelerDrones,
+  minerMineraiManuellement,
+  vendreTousLesMinerais,
+  acheterDroneMinier,
+  deployerDrones,
+  rappelerDrones,
 } from './game/systemeMinage'
 import { acheterMineraiEnStation, vendreMineraiEnStation } from './game/systemeCommerce'
 import { ravitaillerCarburant } from './game/systemeRavitaillement'
 import { ameliorerVaisseau } from './game/systemeAmeliorations'
+import { reparerPartiellementVaisseauActif, reparerVaisseauActif } from './game/systemeReparation'
 import {
-    reparerPartiellementVaisseauActif,
-    reparerVaisseauActif,
-} from './game/systemeReparation'
-import {
-    selectionnerDestination,
-    lancerVoyageVersDestinationSelectionnee,
+  selectionnerDestination,
+  lancerVoyageVersDestinationSelectionnee,
 } from './game/systemeNavigation'
 import { allerEnZoneOperations, retourALaStation } from './game/systemeLocalisation'
 import { scannerAmasMinier } from './game/systemeExploration'
@@ -41,217 +39,218 @@ import { acheterVaisseau, changerVaisseauActif } from './game/systemeVaisseaux'
 const etat = reactive({})
 
 function creerEtatUIInitial() {
-    return {
-        modeActif: 'station',
-        sousModeStation: 'commerce',
-    }
+  return {
+    modeActif: 'station',
+    sousModeStation: 'commerce',
+  }
 }
 
 const ui = reactive(creerEtatUIInitial())
 
 const secteurCourantComplet = computed(
-    () => donneesSecteurs.find((secteur) => secteur.id === etat.secteurCourant?.id) || null,
+  () => donneesSecteurs.find((secteur) => secteur.id === etat.secteurCourant?.id) || null,
 )
 
 const stationCourante = computed(() => secteurCourantComplet.value?.stationPrincipale ?? null)
 
 function normaliserSousModeStation() {
-    const services = stationCourante.value?.services
+  const services = stationCourante.value?.services
 
-    if (ui.sousModeStation === 'hangar') {
-        return
-    }
+  if (ui.sousModeStation === 'hangar') {
+    return
+  }
 
-    if (!services) {
-        ui.sousModeStation = 'hangar'
-        return
-    }
-
-    if (ui.sousModeStation === 'commerce' && services.commerce) return
-    if (ui.sousModeStation === 'ravitaillement' && services.ravitaillement) return
-    if (ui.sousModeStation === 'atelier' && services.atelier) return
-
+  if (!services) {
     ui.sousModeStation = 'hangar'
+    return
+  }
+
+  if (ui.sousModeStation === 'commerce' && services.commerce) return
+  if (ui.sousModeStation === 'ravitaillement' && services.ravitaillement) return
+  if (ui.sousModeStation === 'atelier' && services.atelier) return
+
+  ui.sousModeStation = 'hangar'
 }
 
 function synchroniserModeActifAvecPositionLocale() {
-    if (etat.positionLocale === 'station') {
-        ui.modeActif = 'station'
-        normaliserSousModeStation()
-        return
-    }
+  if (etat.positionLocale === 'station') {
+    ui.modeActif = 'station'
+    normaliserSousModeStation()
+    return
+  }
 
-    if (etat.positionLocale === 'operations') {
-        ui.modeActif = 'operations'
-    }
+  if (etat.positionLocale === 'operations') {
+    ui.modeActif = 'operations'
+  }
 }
 
 function synchroniserEtat() {
-    const etatCourant = structuredClone(recupererEtatJeu())
+  const etatCourant = structuredClone(recupererEtatJeu())
 
-    Object.keys(etat).forEach((cle) => {
-        delete etat[cle]
-    })
+  Object.keys(etat).forEach((cle) => {
+    delete etat[cle]
+  })
 
-    Object.assign(etat, etatCourant)
+  Object.assign(etat, etatCourant)
 
-    synchroniserModeActifAvecPositionLocale()
+  synchroniserModeActifAvecPositionLocale()
 }
 
 function gererMinageManuel() {
-    minerMineraiManuellement()
-    sauvegarderJeu()
-    synchroniserEtat()
+  minerMineraiManuellement()
+  sauvegarderJeu()
+  synchroniserEtat()
 }
 
 function gererScanner() {
-    scannerAmasMinier()
-    sauvegarderJeu()
-    synchroniserEtat()
+  scannerAmasMinier()
+  sauvegarderJeu()
+  synchroniserEtat()
 }
 
 function gererVenteMinerai() {
-    vendreTousLesMinerais()
-    sauvegarderJeu()
-    synchroniserEtat()
+  vendreTousLesMinerais()
+  sauvegarderJeu()
+  synchroniserEtat()
 }
 
 function gererVenteBien(idBien, quantite = 1) {
-    vendreMineraiEnStation(idBien, quantite)
-    sauvegarderJeu()
-    synchroniserEtat()
+  vendreMineraiEnStation(idBien, quantite)
+  sauvegarderJeu()
+  synchroniserEtat()
 }
 
 function gererAchatBien(idBien, quantite = 1) {
-    acheterMineraiEnStation(idBien, quantite)
-    sauvegarderJeu()
-    synchroniserEtat()
+  acheterMineraiEnStation(idBien, quantite)
+  sauvegarderJeu()
+  synchroniserEtat()
 }
 
 function gererAchatDrone() {
-    acheterDroneMinier()
-    sauvegarderJeu()
-    synchroniserEtat()
+  acheterDroneMinier()
+  sauvegarderJeu()
+  synchroniserEtat()
 }
 
 function gererDeploiementDrones() {
-    deployerDrones()
-    sauvegarderJeu()
-    synchroniserEtat()
+  deployerDrones()
+  sauvegarderJeu()
+  synchroniserEtat()
 }
 
 function gererRappelDrones() {
-    rappelerDrones()
-    sauvegarderJeu()
-    synchroniserEtat()
+  rappelerDrones()
+  sauvegarderJeu()
+  synchroniserEtat()
 }
 
 function gererRavitaillement() {
-    ravitaillerCarburant()
-    sauvegarderJeu()
-    synchroniserEtat()
+  ravitaillerCarburant()
+  sauvegarderJeu()
+  synchroniserEtat()
 }
 
 function gererReparationVaisseau() {
-    reparerVaisseauActif()
-    sauvegarderJeu()
-    synchroniserEtat()
+  reparerVaisseauActif()
+  sauvegarderJeu()
+  synchroniserEtat()
 }
 
 function gererReparationPartielleVaisseau() {
-    reparerPartiellementVaisseauActif()
-    sauvegarderJeu()
-    synchroniserEtat()
+  reparerPartiellementVaisseauActif()
+  sauvegarderJeu()
+  synchroniserEtat()
 }
 
 function gererVoyage() {
-    lancerVoyageVersDestinationSelectionnee()
-    sauvegarderJeu()
-    synchroniserEtat()
+  lancerVoyageVersDestinationSelectionnee()
+  sauvegarderJeu()
+  synchroniserEtat()
 }
 
 function gererSelectionDestination(idDestination) {
-    selectionnerDestination(idDestination)
-    sauvegarderJeu()
-    synchroniserEtat()
+  selectionnerDestination(idDestination)
+  sauvegarderJeu()
+  synchroniserEtat()
 }
 
 function gererAmelioration(idAmelioration) {
-    ameliorerVaisseau(idAmelioration)
-    sauvegarderJeu()
-    synchroniserEtat()
+  ameliorerVaisseau(idAmelioration)
+  sauvegarderJeu()
+  synchroniserEtat()
 }
 
 function gererAllerOperations() {
-    const positionAvant = etat.positionLocale
+  const positionAvant = etat.positionLocale
 
-    allerEnZoneOperations()
-    sauvegarderJeu()
-    synchroniserEtat()
+  allerEnZoneOperations()
+  sauvegarderJeu()
+  synchroniserEtat()
 
-    if (positionAvant !== etat.positionLocale && etat.positionLocale === 'operations') {
-        ui.modeActif = 'operations'
-    }
+  if (positionAvant !== etat.positionLocale && etat.positionLocale === 'operations') {
+    ui.modeActif = 'operations'
+  }
 }
 
 function gererRetourStation() {
-    const positionAvant = etat.positionLocale
+  const positionAvant = etat.positionLocale
 
-    retourALaStation()
-    sauvegarderJeu()
-    synchroniserEtat()
+  retourALaStation()
+  sauvegarderJeu()
+  synchroniserEtat()
 
-    if (positionAvant !== etat.positionLocale && etat.positionLocale === 'station') {
-        ui.modeActif = 'station'
-        normaliserSousModeStation()
-    }
+  if (positionAvant !== etat.positionLocale && etat.positionLocale === 'station') {
+    ui.modeActif = 'station'
+    normaliserSousModeStation()
+  }
 }
 
 function gererChangerVaisseau(idVaisseau) {
-    changerVaisseauActif(idVaisseau)
-    sauvegarderJeu()
-    synchroniserEtat()
+  changerVaisseauActif(idVaisseau)
+  sauvegarderJeu()
+  synchroniserEtat()
 }
 
 function gererAcheterVaisseau(modeleId) {
-    acheterVaisseau(modeleId)
-    sauvegarderJeu()
-    synchroniserEtat()
+  acheterVaisseau(modeleId)
+  sauvegarderJeu()
+  synchroniserEtat()
 }
 
 function gererReinitialisation() {
-    reinitialiserEtatJeu()
-    Object.assign(ui, creerEtatUIInitial())
-    sauvegarderJeu()
-    synchroniserEtat()
+  reinitialiserEtatJeu()
+  Object.assign(ui, creerEtatUIInitial())
+  sauvegarderJeu()
+  synchroniserEtat()
 }
 
 function changerMode(mode) {
-    ui.modeActif = mode
-    if (mode === 'station') {
-        normaliserSousModeStation()
-    }
+  ui.modeActif = mode
+  if (mode === 'station') {
+    normaliserSousModeStation()
+  }
 }
 
 function changerSousModeStation(sousMode) {
-    ui.sousModeStation = sousMode
+  ui.sousModeStation = sousMode
 }
 
 onMounted(() => {
-    chargerJeu()
-    synchroniserEtat()
-    demarrerBoucleJeu(synchroniserEtat)
+  chargerJeu()
+  synchroniserEtat()
+  demarrerBoucleJeu(synchroniserEtat)
 })
 
 onUnmounted(() => {
-    arreterBoucleJeu()
+  arreterBoucleJeu()
 })
 </script>
 
 <template>
-    <main
-        class="app-shell"
-        v-if="
+  <main
+    class="app-shell"
+    v-if="
+      etat.joueur &&
       etat.ressources &&
       etat.vaisseau &&
       etat.vaisseauxPossedes &&
@@ -264,128 +263,132 @@ onUnmounted(() => {
       etat.exploration &&
       etat.assistance
     "
-    >
-        <header class="app-header">
-            <div class="header-top">
-                <div class="header-brand">
-                    <h1 class="title-line">
-                        <span class="title-icon">✦</span>
-                        <span>New Horizon</span>
-                        <span class="title-icon">✦</span>
-                    </h1>
+  >
+    <header class="app-header">
+      <div class="header-top">
+        <div class="header-brand">
+          <h1 class="title-line">
+            <span class="title-icon">✦</span>
+            <span>New Horizon</span>
+            <span class="title-icon">✦</span>
+          </h1>
 
-                    <p class="subtitle">
-                        Simulation spatiale incrémentale de prospection minière et de commerce
-                    </p>
+          <p class="subtitle">
+            Simulation spatiale incrémentale de prospection minière et de commerce
+          </p>
 
-                    <p class="meta-line">
-                        v{{ etat.meta?.version }} — {{ etat.meta?.auteur }} — {{ etat.meta?.annee }}
-                    </p>
-                </div>
-
-                <HeaderActions
-                    :mode-actif="ui.modeActif"
-                    @changer-mode="changerMode"
-                    @reinitialiser="gererReinitialisation"
-                />
-            </div>
-        </header>
-
-        <div class="app-main">
-            <section class="main-column main-column-left">
-                <ResourcePanel
-                    :ressources="etat.ressources"
-                    :vaisseau="etat.vaisseau"
-                    :secteur-courant="etat.secteurCourant"
-                />
-                <ShipPanel :vaisseau="etat.vaisseau" :industrie="etat.industrie" />
-                <NavigationPanel
-                    :secteur-courant-id="etat.secteurCourant.id"
-                    :navigation="etat.navigation"
-                    :position-locale="etat.positionLocale"
-                    @selectionner-destination="gererSelectionDestination"
-                    @voyager="gererVoyage"
-                />
-            </section>
-
-            <section class="main-column main-column-center">
-                <div class="center-top">
-                    <OperationPanel
-                        v-if="ui.modeActif === 'operations'"
-                        :ressources="etat.ressources"
-                        :vaisseau="etat.vaisseau"
-                        :industrie="etat.industrie"
-                        :navigation="etat.navigation"
-                        :position-locale="etat.positionLocale"
-                        :exploration="etat.exploration"
-                        :assistance="etat.assistance"
-                        @miner="gererMinageManuel"
-                        @scanner="gererScanner"
-                        @aller-operations="gererAllerOperations"
-                        @retour-station="gererRetourStation"
-                        @deployer-drones="gererDeploiementDrones"
-                        @rappeler-drones="gererRappelDrones"
-                    />
-
-                    <StationServicesPanel
-                        v-else-if="ui.modeActif === 'station'"
-                        :secteur-courant="etat.secteurCourant"
-                        :vaisseau="etat.vaisseau"
-                        :ressources="etat.ressources"
-                        :sous-mode-station="ui.sousModeStation"
-                        :position-locale="etat.positionLocale"
-                        :economie="etat.economie"
-                        @changer-sous-mode-station="changerSousModeStation"
-                        @vendre="gererVenteMinerai"
-                        @vendre-bien="gererVenteBien"
-                        @acheter-bien="gererAchatBien"
-                        @ravitailler="gererRavitaillement"
-                        @acheter-drone="gererAchatDrone"
-                        @reparer-vaisseau="gererReparationVaisseau"
-                        @reparer-partiellement-vaisseau="gererReparationPartielleVaisseau"
-                        @retour-station="gererRetourStation"
-                        @aller-operations="gererAllerOperations"
-                    >
-                        <template #hangar>
-                            <HangarPanel
-                                :secteur-courant="etat.secteurCourant"
-                                :vaisseau-actif-id="etat.vaisseauActifId"
-                                :vaisseaux-possedes="etat.vaisseauxPossedes"
-                                :vaisseau="etat.vaisseau"
-                                :ressources="etat.ressources"
-                                @changer-vaisseau="gererChangerVaisseau"
-                                @acheter-vaisseau="gererAcheterVaisseau"
-                            />
-                        </template>
-
-                        <template #atelier>
-                            <UpgradePanel
-                                :vaisseau="etat.vaisseau"
-                                :secteur-courant="etat.secteurCourant"
-                                @ameliorer="gererAmelioration"
-                            />
-                        </template>
-                    </StationServicesPanel>
-
-                    <NavigationPanel
-                        v-else-if="ui.modeActif === 'navigation'"
-                        :secteur-courant-id="etat.secteurCourant.id"
-                        :navigation="etat.navigation"
-                        :position-locale="etat.positionLocale"
-                        @selectionner-destination="gererSelectionDestination"
-                        @voyager="gererVoyage"
-                    />
-                </div>
-
-                <section class="journal-panel">
-                    <LogPanel :entrees="etat.journal" />
-                </section>
-            </section>
-
-            <aside class="right-aside">
-                <SectorPanel :secteur-courant="etat.secteurCourant" />
-                <StationPanel :secteur-courant="etat.secteurCourant" />
-            </aside>
+          <p class="meta-line">
+            v{{ etat.meta?.version }} — {{ etat.meta?.auteur }} — {{ etat.meta?.annee }}
+          </p>
         </div>
-    </main>
+
+        <HeaderActions
+          :mode-actif="ui.modeActif"
+          @changer-mode="changerMode"
+          @reinitialiser="gererReinitialisation"
+        />
+      </div>
+    </header>
+
+    <div class="app-main">
+      <section class="main-column main-column-left">
+        <PlayerPanel :player="etat.joueur" :credits="etat.ressources.credits" />
+
+        <ResourcePanel
+          :ressources="etat.ressources"
+          :vaisseau="etat.vaisseau"
+          :secteur-courant="etat.secteurCourant"
+        />
+
+        <ShipPanel :vaisseau="etat.vaisseau" :industrie="etat.industrie" />
+
+        <NavigationPanel
+          :secteur-courant-id="etat.secteurCourant.id"
+          :navigation="etat.navigation"
+          :position-locale="etat.positionLocale"
+          @selectionner-destination="gererSelectionDestination"
+          @voyager="gererVoyage"
+        />
+      </section>
+
+      <section class="main-column main-column-center">
+        <div class="center-top">
+          <OperationPanel
+            v-if="ui.modeActif === 'operations'"
+            :ressources="etat.ressources"
+            :vaisseau="etat.vaisseau"
+            :industrie="etat.industrie"
+            :navigation="etat.navigation"
+            :position-locale="etat.positionLocale"
+            :exploration="etat.exploration"
+            :assistance="etat.assistance"
+            @miner="gererMinageManuel"
+            @scanner="gererScanner"
+            @aller-operations="gererAllerOperations"
+            @retour-station="gererRetourStation"
+            @deployer-drones="gererDeploiementDrones"
+            @rappeler-drones="gererRappelDrones"
+          />
+
+          <StationServicesPanel
+            v-else-if="ui.modeActif === 'station'"
+            :secteur-courant="etat.secteurCourant"
+            :vaisseau="etat.vaisseau"
+            :ressources="etat.ressources"
+            :sous-mode-station="ui.sousModeStation"
+            :position-locale="etat.positionLocale"
+            :economie="etat.economie"
+            @changer-sous-mode-station="changerSousModeStation"
+            @vendre="gererVenteMinerai"
+            @vendre-bien="gererVenteBien"
+            @acheter-bien="gererAchatBien"
+            @ravitailler="gererRavitaillement"
+            @acheter-drone="gererAchatDrone"
+            @reparer-vaisseau="gererReparationVaisseau"
+            @reparer-partiellement-vaisseau="gererReparationPartielleVaisseau"
+            @retour-station="gererRetourStation"
+            @aller-operations="gererAllerOperations"
+          >
+            <template #hangar>
+              <HangarPanel
+                :secteur-courant="etat.secteurCourant"
+                :vaisseau-actif-id="etat.vaisseauActifId"
+                :vaisseaux-possedes="etat.vaisseauxPossedes"
+                :vaisseau="etat.vaisseau"
+                :ressources="etat.ressources"
+                @changer-vaisseau="gererChangerVaisseau"
+                @acheter-vaisseau="gererAcheterVaisseau"
+              />
+            </template>
+
+            <template #atelier>
+              <UpgradePanel
+                :vaisseau="etat.vaisseau"
+                :secteur-courant="etat.secteurCourant"
+                @ameliorer="gererAmelioration"
+              />
+            </template>
+          </StationServicesPanel>
+
+          <NavigationPanel
+            v-else-if="ui.modeActif === 'navigation'"
+            :secteur-courant-id="etat.secteurCourant.id"
+            :navigation="etat.navigation"
+            :position-locale="etat.positionLocale"
+            @selectionner-destination="gererSelectionDestination"
+            @voyager="gererVoyage"
+          />
+        </div>
+
+        <section class="journal-panel">
+          <LogPanel :entrees="etat.journal" />
+        </section>
+      </section>
+
+      <aside class="right-aside">
+        <SectorPanel :secteur-courant="etat.secteurCourant" />
+        <StationPanel :secteur-courant="etat.secteurCourant" />
+      </aside>
+    </div>
+  </main>
 </template>

--- a/src/App.vue
+++ b/src/App.vue
@@ -53,6 +53,28 @@ const secteurCourantComplet = computed(
 
 const stationCourante = computed(() => secteurCourantComplet.value?.stationPrincipale ?? null)
 
+const temporaliteCourante = computed(() => {
+    const ticksGlobaux = Number(etat.technique?.compteurTicks) || 0
+
+    const ticksParJour = 24
+    const ticksParAn = 8760
+
+    const annee = Math.floor(ticksGlobaux / ticksParAn) + 1
+    const tickDansAnnee = ticksGlobaux % ticksParAn
+    const jour = Math.floor(tickDansAnnee / ticksParJour) + 1
+    const heure = tickDansAnnee % ticksParJour
+
+    return {
+        ticksGlobaux,
+        annee,
+        jour,
+        heure,
+        libelle: `A${annee} · J${jour} · ${String(heure).padStart(2, '0')}h · T${String(
+            ticksGlobaux,
+        ).padStart(4, '0')}`,
+    }
+})
+
 function normaliserSousModeStation() {
     const services = stationCourante.value?.services
 
@@ -273,7 +295,8 @@ onUnmounted(() => {
       etat.navigation &&
       etat.journal &&
       etat.exploration &&
-      etat.assistance
+      etat.assistance &&
+      etat.technique
     "
     >
         <header class="app-header">
@@ -292,6 +315,13 @@ onUnmounted(() => {
                     <p class="meta-line">
                         v{{ etat.meta?.version }} — {{ etat.meta?.auteur }} — {{ etat.meta?.annee }}
                     </p>
+                </div>
+
+                <div class="header-center">
+                    <div class="time-line" aria-label="Temporalité globale du jeu">
+                        <span class="time-line-label">Temps local</span>
+                        <span class="time-line-value">{{ temporaliteCourante.libelle }}</span>
+                    </div>
                 </div>
 
                 <HeaderActions

--- a/src/assets/styles/components/navigation.css
+++ b/src/assets/styles/components/navigation.css
@@ -20,11 +20,25 @@ select {
   color: #eef5fb;
 }
 
+.navigation-destination-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
 .navigation-label {
   display: block;
   margin-bottom: 5px;
   font-size: 0.88rem;
   opacity: 0.9;
+}
+
+.navigation-label--inline {
+  margin-bottom: 0;
+  font-size: 0.82rem;
+  white-space: nowrap;
 }
 
 .navigation-select {
@@ -35,6 +49,20 @@ select {
   border-radius: 6px;
   background: #0f1822;
   color: #eef5fb;
+}
+
+.navigation-select--compact {
+  margin-bottom: 0;
+  padding: 0.38rem 0.55rem;
+  font-size: 0.9rem;
+  line-height: 1.1;
+}
+
+.navigation-route-meta {
+  margin: 0 0 8px;
+  font-size: 0.8rem;
+  line-height: 1.1;
+  opacity: 0.88;
 }
 
 .navigation-status {

--- a/src/assets/styles/components/panels.css
+++ b/src/assets/styles/components/panels.css
@@ -17,10 +17,10 @@
   box-shadow: inset 0 0 0 1px rgba(125, 184, 255, 0.03);
   overflow: hidden;
   transition:
-          border-color var(--nh-motion-duration-fast) var(--nh-motion-ease-standard),
-          box-shadow var(--nh-motion-duration-fast) var(--nh-motion-ease-standard),
-          background var(--nh-motion-duration-fast) var(--nh-motion-ease-standard),
-          opacity var(--nh-motion-duration-fast) var(--nh-motion-ease-standard);
+    border-color var(--nh-motion-duration-fast) var(--nh-motion-ease-standard),
+    box-shadow var(--nh-motion-duration-fast) var(--nh-motion-ease-standard),
+    background var(--nh-motion-duration-fast) var(--nh-motion-ease-standard),
+    opacity var(--nh-motion-duration-fast) var(--nh-motion-ease-standard);
 }
 
 .panel h2 {

--- a/src/assets/styles/features/player.css
+++ b/src/assets/styles/features/player.css
@@ -1,0 +1,81 @@
+/* =========================================================
+   FEATURE — PILOTE
+   ---------------------------------------------------------
+   Rôle :
+   - panneau d’identité du joueur
+   - statut, réputation, fortune
+   - compacité adaptée à la colonne gauche
+   ========================================================= */
+
+.player-panel {
+  position: relative;
+  min-height: unset;
+  padding-bottom: 9px;
+}
+
+.player-panel::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background:
+    linear-gradient(135deg, rgba(125, 184, 255, 0.05), transparent 45%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.015), transparent 55%);
+  pointer-events: none;
+}
+
+.player-panel-header {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+
+.player-panel-header h2 {
+  margin-bottom: 0;
+}
+
+.player-panel-badge {
+  flex: 0 0 auto;
+  padding: 2px 7px;
+  border: 1px solid rgba(125, 184, 255, 0.18);
+  border-radius: 999px;
+  background: rgba(125, 184, 255, 0.08);
+  font-size: 0.64rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  opacity: 0.92;
+}
+
+.player-panel-grid {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 5px;
+}
+
+.player-panel-card {
+  padding: 5px 8px 5px;
+  border: 1px solid rgba(125, 184, 255, 0.08);
+  border-radius: 9px;
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.player-panel-label {
+  display: block;
+  margin-bottom: 1px;
+  font-size: 0.64rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  opacity: 0.66;
+}
+
+.player-panel-value {
+  display: block;
+  font-size: 0.84rem;
+  line-height: 1.05;
+  color: #d8e7f7;
+}

--- a/src/assets/styles/features/player.css
+++ b/src/assets/styles/features/player.css
@@ -18,8 +18,8 @@
   position: absolute;
   inset: 0;
   background:
-    linear-gradient(135deg, rgba(125, 184, 255, 0.05), transparent 45%),
-    linear-gradient(180deg, rgba(255, 255, 255, 0.015), transparent 55%);
+          linear-gradient(135deg, rgba(125, 184, 255, 0.05), transparent 45%),
+          linear-gradient(180deg, rgba(255, 255, 255, 0.015), transparent 55%);
   pointer-events: none;
 }
 
@@ -38,7 +38,9 @@
 }
 
 .player-panel-badge {
-  flex: 0 0 auto;
+  flex: 0 1 auto;
+  min-width: 0;
+  max-width: 58%;
   padding: 2px 7px;
   border: 1px solid rgba(125, 184, 255, 0.18);
   border-radius: 999px;
@@ -47,6 +49,9 @@
   letter-spacing: 0.04em;
   text-transform: uppercase;
   opacity: 0.92;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .player-panel-grid {
@@ -78,4 +83,51 @@
   font-size: 0.84rem;
   line-height: 1.05;
   color: #d8e7f7;
+}
+
+.player-panel-line-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.player-panel-edit-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  padding: 0;
+  border: 1px solid rgba(125, 184, 255, 0.16);
+  border-radius: 999px;
+  background: rgba(125, 184, 255, 0.06);
+  color: #d8e7f7;
+  font-size: 0.68rem;
+  line-height: 1;
+  cursor: pointer;
+  transition:
+          background var(--nh-motion-duration-fast) var(--nh-motion-ease-standard),
+          border-color var(--nh-motion-duration-fast) var(--nh-motion-ease-standard),
+          opacity var(--nh-motion-duration-fast) var(--nh-motion-ease-standard);
+}
+
+.player-panel-edit-button:hover {
+  background: rgba(125, 184, 255, 0.12);
+  border-color: rgba(125, 184, 255, 0.28);
+}
+
+.player-panel-edit-row {
+  margin-top: 2px;
+}
+
+.player-panel-input {
+  width: 100%;
+  padding: 0.34rem 0.45rem;
+  border: 1px solid #3c536b;
+  border-radius: 6px;
+  background: #0f1822;
+  color: #eef5fb;
+  font-size: 0.82rem;
+  line-height: 1.05;
 }

--- a/src/assets/styles/features/ship.css
+++ b/src/assets/styles/features/ship.css
@@ -210,6 +210,106 @@
   color: rgba(210, 225, 245, 0.76);
 }
 
+/* ===== État de carburant ===== */
+
+.ship-panel-fuel-status {
+  margin: 0 0 0.65rem;
+  padding: 0.45rem 0.55rem;
+  border: 1px solid rgba(125, 184, 255, 0.08);
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.02);
+  transition:
+          border-color var(--nh-motion-duration-fast) var(--nh-motion-ease-standard),
+          background var(--nh-motion-duration-fast) var(--nh-motion-ease-standard),
+          box-shadow var(--nh-motion-duration-fast) var(--nh-motion-ease-standard);
+}
+
+.ship-panel-fuel-status-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.45rem;
+  margin-bottom: 0.25rem;
+}
+
+.ship-panel-fuel-title {
+  font-size: 0.66rem;
+  color: rgba(210, 225, 245, 0.64);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.ship-fuel-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.14rem 0.4rem;
+  border-radius: 999px;
+  font-size: 0.6rem;
+  font-weight: 700;
+  white-space: nowrap;
+  line-height: 1;
+  border: 1px solid transparent;
+  transition:
+          border-color var(--nh-motion-duration-fast) var(--nh-motion-ease-standard),
+          background var(--nh-motion-duration-fast) var(--nh-motion-ease-standard),
+          color var(--nh-motion-duration-fast) var(--nh-motion-ease-standard),
+          box-shadow var(--nh-motion-duration-fast) var(--nh-motion-ease-standard);
+}
+
+.ship-fuel-badge--nominal {
+  color: #bfe7ff;
+  background: rgba(58, 112, 168, 0.18);
+  border-color: rgba(90, 158, 224, 0.28);
+}
+
+.ship-fuel-badge--degrade {
+  color: #f5d7a1;
+  background: rgba(168, 104, 32, 0.18);
+  border-color: rgba(214, 146, 58, 0.28);
+}
+
+.ship-fuel-badge--critique {
+  color: #ffb8b8;
+  background: rgba(150, 44, 44, 0.2);
+  border-color: rgba(224, 90, 90, 0.32);
+}
+
+.ship-panel-fuel-bar {
+  width: 100%;
+  height: 5px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.ship-panel-fuel-bar-fill {
+  height: 100%;
+  border-radius: 999px;
+  transition: width var(--nh-motion-duration-medium) var(--nh-motion-ease-standard);
+}
+
+.ship-panel-fuel-bar-fill.ship-fuel-badge--nominal {
+  background: linear-gradient(90deg, rgba(90, 158, 224, 0.72) 0%, rgba(138, 204, 255, 0.96) 100%);
+}
+
+.ship-panel-fuel-bar-fill.ship-fuel-badge--degrade {
+  background: linear-gradient(90deg, rgba(214, 146, 58, 0.7) 0%, rgba(245, 215, 161, 0.95) 100%);
+}
+
+.ship-panel-fuel-bar-fill.ship-fuel-badge--critique {
+  background: linear-gradient(90deg, rgba(170, 60, 60, 0.7) 0%, rgba(255, 184, 184, 0.95) 100%);
+}
+
+.ship-panel-fuel-meta {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin: 0.22rem 0 0;
+  font-size: 0.7rem;
+  color: rgba(210, 225, 245, 0.76);
+}
+
 /* ===== Métriques ===== */
 
 .ship-panel-metrics {

--- a/src/assets/styles/layout/header.css
+++ b/src/assets/styles/layout/header.css
@@ -8,10 +8,9 @@
    ========================================================= */
 
 .header-top {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: minmax(320px, 1fr) auto auto;
+  align-items: start;
   gap: 14px;
 }
 
@@ -44,6 +43,50 @@
   margin: 0;
   font-size: 0.87rem;
   opacity: 0.75;
+}
+
+.header-center {
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  padding-top: 6px;
+}
+
+.time-line {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  width: fit-content;
+  max-width: 100%;
+  padding: 6px 10px;
+  border: 1px solid rgba(125, 184, 255, 0.18);
+  border-radius: 10px;
+  background:
+          linear-gradient(180deg, rgba(7, 18, 31, 0.92), rgba(11, 25, 41, 0.9)),
+          linear-gradient(90deg, rgba(125, 184, 255, 0.08), transparent 45%);
+  box-shadow:
+          inset 0 0 0 1px rgba(125, 184, 255, 0.03),
+          0 0 14px rgba(24, 72, 128, 0.16);
+  overflow: hidden;
+}
+
+.time-line-label {
+  flex: 0 0 auto;
+  font-size: 0.68rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #8db8eb;
+  opacity: 0.88;
+}
+
+.time-line-value {
+  min-width: 0;
+  font-family: 'Courier New', monospace;
+  font-size: 0.9rem;
+  letter-spacing: 0.06em;
+  color: #e5f1ff;
+  text-shadow: 0 0 8px rgba(125, 184, 255, 0.12);
+  white-space: nowrap;
 }
 
 .header-actions {

--- a/src/assets/styles/layout/responsive.css
+++ b/src/assets/styles/layout/responsive.css
@@ -101,6 +101,15 @@
   .market-rate-grid-three-cols {
     grid-template-columns: 1fr;
   }
+
+  .header-top {
+    grid-template-columns: 1fr;
+  }
+
+  .header-center {
+    justify-content: flex-start;
+    padding-top: 0;
+  }
 }
 
 /* =========================================================

--- a/src/assets/styles/main.css
+++ b/src/assets/styles/main.css
@@ -41,6 +41,7 @@
    ========================================================= */
 @import './components/navigation.css';
 @import './components/resources.css';
+@import './features/player.css';
 
 /* =========================================================
    5. ZONE CENTRALE DE PILOTAGE

--- a/src/components/NavigationPanel.vue
+++ b/src/components/NavigationPanel.vue
@@ -12,16 +12,16 @@ const props = defineProps({
     type: Object,
     required: true,
   },
+  positionLocale: {
+    type: String,
+    default: 'station',
+  },
 })
 
 const emit = defineEmits(['selectionner-destination', 'voyager'])
 
 const secteurCourant = computed(() =>
   donneesSecteurs.find((secteur) => secteur.id === props.secteurCourantId),
-)
-
-const secteurDestinationSelectionnee = computed(() =>
-  donneesSecteurs.find((secteur) => secteur.id === props.navigation.destinationSelectionneeId),
 )
 
 const secteurDestinationActive = computed(() =>
@@ -46,6 +46,7 @@ const trajetSelectionne = computed(() =>
     <h2>⟁ Navigation</h2>
 
     <p>Secteur actuel : {{ secteurCourant?.nom }}</p>
+    <p>Position : {{ positionLocale === 'operations' ? 'Zone d’opérations' : 'Station' }}</p>
 
     <template v-if="navigation.enVoyage">
       <p>Destination : {{ secteurDestinationActive?.nom }}</p>
@@ -54,32 +55,38 @@ const trajetSelectionne = computed(() =>
     </template>
 
     <template v-else>
-      <label class="navigation-label" for="destination-select"> Destination </label>
+      <div class="navigation-destination-row">
+        <label class="navigation-label navigation-label--inline" for="destination-select">
+          Destination
+        </label>
 
-      <select
-        id="destination-select"
-        class="navigation-select"
-        :value="navigation.destinationSelectionneeId"
-        @change="emit('selectionner-destination', $event.target.value)"
-      >
-        <option v-for="secteur in autresSecteurs" :key="secteur.id" :value="secteur.id">
-          {{ secteur.nom }}
-        </option>
-      </select>
+        <select
+          id="destination-select"
+          class="navigation-select navigation-select--compact"
+          :value="navigation.destinationSelectionneeId"
+          @change="emit('selectionner-destination', $event.target.value)"
+        >
+          <option v-for="secteur in autresSecteurs" :key="secteur.id" :value="secteur.id">
+            {{ secteur.nom }}
+          </option>
+        </select>
+      </div>
 
-      <template v-if="secteurDestinationSelectionnee && trajetSelectionne">
-        <p>Coût carburant : {{ trajetSelectionne.coutCarburant }}</p>
-        <p>Durée du trajet : {{ trajetSelectionne.tempsTrajet }} ticks</p>
+      <template v-if="trajetSelectionne">
+        <p class="navigation-route-meta">
+          Durée : {{ trajetSelectionne.tempsTrajet }} ticks · Coût carburant :
+          {{ trajetSelectionne.coutCarburant }}
+        </p>
       </template>
 
       <div class="action-group">
-        <button class="action-button-with-icon" @click="$emit('voyager')">
+        <button class="action-button-with-icon" @click="emit('voyager')">
           <span class="button-icon" aria-hidden="true">🧭</span>
           <span>Lancer le trajet</span>
         </button>
       </div>
 
-      <p class="navigation-status">Statut : À quai</p>
+      <p class="navigation-status">Statut : Prêt au départ</p>
     </template>
   </section>
 </template>

--- a/src/components/PlayerPanel.vue
+++ b/src/components/PlayerPanel.vue
@@ -1,0 +1,45 @@
+<script setup>
+defineProps({
+  player: {
+    type: Object,
+    default: () => ({}),
+  },
+  credits: {
+    type: Number,
+    default: 0,
+  },
+})
+</script>
+
+<template>
+  <section class="panel player-panel">
+    <div class="player-panel-header">
+      <h2>◉ Pilote</h2>
+
+      <span class="player-panel-badge">
+        {{ player?.statut || 'Indépendant' }}
+      </span>
+    </div>
+
+    <div class="player-panel-grid">
+      <div class="player-panel-card">
+        <span class="player-panel-label">Identité</span>
+        <strong class="player-panel-value">
+          {{ player?.identite || 'À renseigner' }}
+        </strong>
+      </div>
+
+      <div class="player-panel-card">
+        <span class="player-panel-label">Réputation</span>
+        <strong class="player-panel-value">
+          {{ player?.reputation || 'Inconnue' }}
+        </strong>
+      </div>
+
+      <div class="player-panel-card">
+        <span class="player-panel-label">Fortune</span>
+        <strong class="player-panel-value"> {{ credits }} crédits </strong>
+      </div>
+    </div>
+  </section>
+</template>

--- a/src/components/PlayerPanel.vue
+++ b/src/components/PlayerPanel.vue
@@ -1,45 +1,120 @@
 <script setup>
-defineProps({
-  player: {
-    type: Object,
-    default: () => ({}),
-  },
-  credits: {
-    type: Number,
-    default: 0,
-  },
+import { computed, ref, watch } from 'vue'
+
+const props = defineProps({
+    player: {
+        type: Object,
+        default: () => ({}),
+    },
+    credits: {
+        type: Number,
+        default: 0,
+    },
 })
+
+const emit = defineEmits(['renommer-pilote'])
+
+const modeEditionNom = ref(false)
+const identiteBrouillon = ref('')
+
+const identiteAffichee = computed(() => props.player?.identite || 'Sans indicatif')
+
+const statutEconomique = computed(() => {
+    const credits = Number(props.credits) || 0
+
+    if (credits >= 20000000) return 'VII — Consortium privé'
+    if (credits >= 5000000) return 'VI — Armateur privé'
+    if (credits >= 1000000) return 'V — Magnat local'
+    if (credits >= 250000) return 'IV — Exploitant'
+    if (credits >= 50000) return 'III — Opérateur'
+    if (credits >= 10000) return 'II — Freelancer'
+    return 'I — Indépendant'
+})
+
+const reputationAffichee = computed(() => props.player?.reputation || 'I — Neutre')
+
+watch(
+    () => props.player?.identite,
+    (nouvelleIdentite) => {
+        identiteBrouillon.value = nouvelleIdentite || 'Sans indicatif'
+    },
+    { immediate: true },
+)
+
+function activerEditionNom() {
+    identiteBrouillon.value = identiteAffichee.value
+    modeEditionNom.value = true
+}
+
+function validerEditionNom() {
+    const valeurNettoyee = (identiteBrouillon.value || '').trim()
+    emit('renommer-pilote', valeurNettoyee || 'Sans indicatif')
+    modeEditionNom.value = false
+}
+
+function annulerEditionNom() {
+    identiteBrouillon.value = identiteAffichee.value
+    modeEditionNom.value = false
+}
 </script>
 
 <template>
-  <section class="panel player-panel">
-    <div class="player-panel-header">
-      <h2>◉ Pilote</h2>
+    <section class="panel player-panel">
+        <div class="player-panel-header">
+            <h2>◉ Pilote</h2>
 
-      <span class="player-panel-badge">
-        {{ player?.statut || 'Indépendant' }}
+            <span class="player-panel-badge">
+        {{ statutEconomique }}
       </span>
-    </div>
+        </div>
 
-    <div class="player-panel-grid">
-      <div class="player-panel-card">
-        <span class="player-panel-label">Identité</span>
-        <strong class="player-panel-value">
-          {{ player?.identite || 'À renseigner' }}
-        </strong>
-      </div>
+        <div class="player-panel-grid">
+            <div class="player-panel-card">
+                <div class="player-panel-line-header">
+                    <span class="player-panel-label">Identité</span>
 
-      <div class="player-panel-card">
-        <span class="player-panel-label">Réputation</span>
-        <strong class="player-panel-value">
-          {{ player?.reputation || 'Inconnue' }}
-        </strong>
-      </div>
+                    <button
+                        v-if="!modeEditionNom"
+                        type="button"
+                        class="player-panel-edit-button"
+                        @click="activerEditionNom"
+                        aria-label="Modifier l'identité du pilote"
+                        title="Modifier l'identité du pilote"
+                    >
+                        ✎
+                    </button>
+                </div>
 
-      <div class="player-panel-card">
-        <span class="player-panel-label">Fortune</span>
-        <strong class="player-panel-value"> {{ credits }} crédits </strong>
-      </div>
-    </div>
-  </section>
+                <div v-if="modeEditionNom" class="player-panel-edit-row">
+                    <input
+                        v-model="identiteBrouillon"
+                        type="text"
+                        maxlength="40"
+                        class="player-panel-input"
+                        @keydown.enter.prevent="validerEditionNom"
+                        @keydown.esc.prevent="annulerEditionNom"
+                        @blur="validerEditionNom"
+                    />
+                </div>
+
+                <strong v-else class="player-panel-value">
+                    {{ identiteAffichee }}
+                </strong>
+            </div>
+
+            <div class="player-panel-card">
+                <span class="player-panel-label">Réputation</span>
+                <strong class="player-panel-value">
+                    {{ reputationAffichee }}
+                </strong>
+            </div>
+
+            <div class="player-panel-card">
+                <span class="player-panel-label">Fortune</span>
+                <strong class="player-panel-value">
+                    {{ credits }} crédits
+                </strong>
+            </div>
+        </div>
+    </section>
 </template>

--- a/src/components/ResourcePanel.vue
+++ b/src/components/ResourcePanel.vue
@@ -1,10 +1,7 @@
 <script setup>
-import { computed } from 'vue'
 import { donneesMinerais } from '../game/dataMinerais'
-import { donneesSecteurs } from '../game/dataSecteurs'
-import { calculerValeurCargaisonPourStation } from '../game/systemeCommerce'
 
-const props = defineProps({
+defineProps({
   ressources: {
     type: Object,
     required: true,
@@ -18,38 +15,12 @@ const props = defineProps({
     required: true,
   },
 })
-
-const secteur = computed(() =>
-  donneesSecteurs.find((entree) => entree.id === props.secteurCourant.id),
-)
-
-const stationCourante = computed(() => secteur.value?.stationPrincipale ?? null)
-
-const estimationCargaison = computed(() => {
-  if (!stationCourante.value || !secteur.value) {
-    return {
-      valeurBrute: 0,
-      montantTaxe: 0,
-      valeurNette: 0,
-    }
-  }
-
-  return calculerValeurCargaisonPourStation(
-    props.ressources.minerais,
-    stationCourante.value,
-    secteur.value.securite,
-  )
-})
 </script>
 
 <template>
   <section class="panel">
     <h2>◈ Ressources</h2>
-    <p>Crédits : {{ ressources.credits }}</p>
     <p>Carburant : {{ ressources.carburant }} / {{ vaisseau.carburantMax }}</p>
-    <p>Soute : {{ vaisseau.soute }} / {{ vaisseau.souteMax }}</p>
-    <p>Valeur brute estimée : {{ estimationCargaison.valeurBrute }} crédits</p>
-    <p>Valeur nette estimée : {{ estimationCargaison.valeurNette }} crédits</p>
 
     <h3>Contenu minéral de la soute</h3>
     <ul class="resource-list resource-list-compact resource-list-mineraux">

--- a/src/components/ResourcePanel.vue
+++ b/src/components/ResourcePanel.vue
@@ -2,35 +2,34 @@
 import { donneesMinerais } from '../game/dataMinerais'
 
 defineProps({
-  ressources: {
-    type: Object,
-    required: true,
-  },
-  vaisseau: {
-    type: Object,
-    required: true,
-  },
-  secteurCourant: {
-    type: Object,
-    required: true,
-  },
+    ressources: {
+        type: Object,
+        required: true,
+    },
+    vaisseau: {
+        type: Object,
+        required: true,
+    },
+    secteurCourant: {
+        type: Object,
+        required: true,
+    },
 })
 </script>
 
 <template>
-  <section class="panel">
-    <h2>◈ Ressources</h2>
-    <p>Carburant : {{ ressources.carburant }} / {{ vaisseau.carburantMax }}</p>
+    <section class="panel">
+        <h2>◈ Ressources</h2>
 
-    <h3>Contenu minéral de la soute</h3>
-    <ul class="resource-list resource-list-compact resource-list-mineraux">
-      <li v-for="minerai in donneesMinerais" :key="minerai.id">
+        <h3>Contenu minéral de la soute</h3>
+        <ul class="resource-list resource-list-compact resource-list-mineraux">
+            <li v-for="minerai in donneesMinerais" :key="minerai.id">
         <span class="resource-inline">
           <span class="resource-icon">{{ minerai.icone }}</span>
           <span class="resource-name">{{ minerai.abreviation }}</span>
         </span>
-        <span class="resource-value">{{ ressources.minerais[minerai.id] || 0 }}</span>
-      </li>
-    </ul>
-  </section>
+                <span class="resource-value">{{ ressources.minerais[minerai.id] || 0 }}</span>
+            </li>
+        </ul>
+    </section>
 </template>

--- a/src/components/ShipPanel.vue
+++ b/src/components/ShipPanel.vue
@@ -1,7 +1,5 @@
 <script setup>
 import { computed } from 'vue'
-import { recupererEtatCoque } from '../game/systemeCoque'
-import { recupererEtatVisuelCoque } from '../game/systemeEtatsVisuels'
 
 const props = defineProps({
     vaisseau: {
@@ -12,55 +10,102 @@ const props = defineProps({
         type: Object,
         required: true,
     },
+    ressources: {
+        type: Object,
+        required: true,
+    },
 })
 
 const roleLabel = computed(() => {
-    if (props.vaisseau?.role === 'mineur_leger') return 'Mineur léger'
-    if (props.vaisseau?.role === 'mineur_lourd') return 'Mineur lourd'
-    if (props.vaisseau?.role === 'mineur_renforce') return 'Mineur renforcé'
-    if (props.vaisseau?.role === 'transporteur_marchand') return 'Transporteur marchand'
-    return 'Châssis polyvalent'
+    switch (props.vaisseau.role) {
+        case 'mineur_leger':
+            return 'Mineur léger'
+        case 'mineur_renforce':
+            return 'Mineur renforcé'
+        case 'mineur_lourd':
+            return 'Mineur lourd'
+        case 'transporteur_marchand':
+            return 'Transporteur marchand'
+        default:
+            return 'Vaisseau'
+    }
 })
 
-const accrocheRole = computed(() => {
-    if (props.vaisseau?.role === 'transporteur_marchand') {
-        return 'Conçu pour le fret et les rotations commerciales.'
+const roleClass = computed(() => {
+    switch (props.vaisseau.role) {
+        case 'mineur_leger':
+            return 'ship-role-badge--light'
+        case 'mineur_renforce':
+            return 'ship-role-badge--reinforced'
+        case 'mineur_lourd':
+            return 'ship-role-badge--heavy'
+        case 'transporteur_marchand':
+            return 'ship-role-badge--trade'
+        default:
+            return 'ship-role-badge--light'
     }
-
-    if (props.vaisseau?.role === 'mineur_lourd') {
-        return 'Pensé pour l’extraction soutenue et le rendement.'
-    }
-
-    if (props.vaisseau?.role === 'mineur_renforce') {
-        return 'Prévu pour l’exploitation en zones plus exigeantes.'
-    }
-
-    return 'Châssis utilitaire d’extraction légère.'
 })
 
-const badgeRoleClasse = computed(() => {
-    if (props.vaisseau?.role === 'transporteur_marchand') {
-        return 'ship-role-badge ship-role-badge--trade'
-    }
+const descriptionVaisseau = computed(() => props.vaisseau.description || 'Vaisseau opérationnel.')
 
-    if (props.vaisseau?.role === 'mineur_lourd') {
-        return 'ship-role-badge ship-role-badge--heavy'
-    }
-
-    if (props.vaisseau?.role === 'mineur_renforce') {
-        return 'ship-role-badge ship-role-badge--reinforced'
-    }
-
-    return 'ship-role-badge ship-role-badge--light'
+const coquePourcentage = computed(() => {
+    if (!props.vaisseau.coqueMax) return 0
+    return Math.max(0, Math.min(100, Math.round((props.vaisseau.coque / props.vaisseau.coqueMax) * 100)))
 })
 
-const infosCoque = computed(() =>
-    recupererEtatCoque(props.vaisseau?.coque ?? 0, props.vaisseau?.coqueMax ?? 0),
-)
+const etatCoque = computed(() => {
+    const pourcentage = coquePourcentage.value
 
-const etatVisuelCoque = computed(() => recupererEtatVisuelCoque(infosCoque.value.code))
+    if (pourcentage <= 0) {
+        return {
+            libelle: 'Hors service',
+            classeCss: 'ship-hull-badge--hors-service',
+        }
+    }
 
-const largeurBarreCoque = computed(() => `${infosCoque.value.pourcentage}%`)
+    if (pourcentage <= 39) {
+        return {
+            libelle: 'Critique',
+            classeCss: 'ship-hull-badge--critique',
+        }
+    }
+
+    if (pourcentage <= 74) {
+        return {
+            libelle: 'Dégradée',
+            classeCss: 'ship-hull-badge--degradee',
+        }
+    }
+
+    return {
+        libelle: 'Nominale',
+        classeCss: 'ship-hull-badge--nominale',
+    }
+})
+
+const carburantActuel = computed(() => Number(props.ressources?.carburant) || 0)
+
+const carburantPourcentage = computed(() => {
+    if (!props.vaisseau.carburantMax) return 0
+    return Math.max(
+        0,
+        Math.min(100, Math.round((carburantActuel.value / props.vaisseau.carburantMax) * 100)),
+    )
+})
+
+const carburantEtatClass = computed(() => {
+    if (carburantPourcentage.value <= 15) return 'ship-fuel-badge--critique'
+    if (carburantPourcentage.value <= 40) return 'ship-fuel-badge--degrade'
+    return 'ship-fuel-badge--nominal'
+})
+
+const carburantEtatLibelle = computed(() => {
+    if (carburantPourcentage.value <= 15) return 'Réserve critique'
+    if (carburantPourcentage.value <= 40) return 'Réserve basse'
+    return 'Réserve correcte'
+})
+
+const nombreDronesActifs = computed(() => props.industrie?.drones?.length || 0)
 </script>
 
 <template>
@@ -69,53 +114,75 @@ const largeurBarreCoque = computed(() => `${infosCoque.value.pourcentage}%`)
             <div class="ship-panel-title-block">
                 <h2>⛭ Vaisseau</h2>
                 <p class="ship-panel-subtitle">
-          <span class="ship-panel-ship-group">
-            <span class="ship-panel-ship-name">{{ vaisseau.nom }}</span>
-            <span class="ship-panel-separator"> — </span>
-          </span>
+                    <span class="ship-panel-ship-name">{{ vaisseau.nom }}</span>
+                    <span class="ship-panel-separator">—</span>
                     <span class="ship-panel-builder">{{ vaisseau.constructeur }}</span>
                 </p>
             </div>
 
-            <span :class="badgeRoleClasse">
+            <span class="ship-role-badge" :class="roleClass">
         {{ roleLabel }}
       </span>
         </div>
 
-        <p class="ship-panel-role-line">
-            {{ accrocheRole }}
-        </p>
+        <p class="ship-panel-role-line">{{ descriptionVaisseau }}</p>
 
         <div class="ship-panel-hull-status ship-panel-hull-status--compact">
             <div class="ship-panel-hull-status-head">
                 <span class="ship-panel-hull-title">Intégrité de coque</span>
-                <span :class="etatVisuelCoque.classeBadge">{{ etatVisuelCoque.label }}</span>
+                <span class="ship-hull-badge" :class="etatCoque.classeCss">
+          {{ etatCoque.libelle }}
+        </span>
             </div>
 
             <div class="ship-panel-hull-bar">
                 <div
                     class="ship-panel-hull-bar-fill"
-                    :class="etatVisuelCoque.classeBarre"
-                    :style="{ width: largeurBarreCoque }"
-                ></div>
+                    :class="etatCoque.classeCss"
+                    :style="{ width: `${coquePourcentage}%` }"
+                />
             </div>
 
-            <p class="ship-panel-hull-meta">
+            <div class="ship-panel-hull-meta">
                 <span>{{ vaisseau.coque }} / {{ vaisseau.coqueMax }}</span>
-                <span>{{ infosCoque.pourcentage }}%</span>
-            </p>
+                <span>{{ coquePourcentage }}%</span>
+            </div>
+        </div>
+
+        <div class="ship-panel-fuel-status">
+            <div class="ship-panel-fuel-status-head">
+                <span class="ship-panel-fuel-title">Carburant</span>
+                <span class="ship-fuel-badge" :class="carburantEtatClass">
+          {{ carburantPourcentage }}%
+        </span>
+            </div>
+
+            <div class="ship-panel-fuel-bar">
+                <div
+                    class="ship-panel-fuel-bar-fill"
+                    :class="carburantEtatClass"
+                    :style="{ width: `${carburantPourcentage}%` }"
+                />
+            </div>
+
+            <div class="ship-panel-fuel-meta">
+                <span>{{ carburantActuel }} / {{ vaisseau.carburantMax }}</span>
+                <span>{{ carburantEtatLibelle }}</span>
+            </div>
         </div>
 
         <div class="ship-panel-metrics ship-panel-metrics--three-cols">
             <p>
-                <span>Soute</span><strong>{{ vaisseau.soute }} / {{ vaisseau.souteMax }}</strong>
+                <span>Soute</span>
+                <strong>{{ vaisseau.soute }} / {{ vaisseau.souteMax }}</strong>
             </p>
             <p>
-                <span>Canon minier</span><strong>{{ vaisseau.puissanceMiniere }}</strong>
+                <span>Canon minier</span>
+                <strong>{{ vaisseau.puissanceMiniere }}</strong>
             </p>
             <p>
-        <span>Drones</span
-        ><strong>{{ industrie.drones.length }} / {{ vaisseau.dronesMiniersMax }}</strong>
+                <span>Drones</span>
+                <strong>{{ nombreDronesActifs }} / {{ vaisseau.dronesMiniersMax }}</strong>
             </p>
         </div>
     </section>

--- a/src/game/donneesInitiales.js
+++ b/src/game/donneesInitiales.js
@@ -38,10 +38,8 @@ export function creerEtatInitialJeu() {
     },
 
     joueur: {
-      identite: 'À renseigner',
-      statut: 'Indépendant',
-      reputation: 'Inconnue',
-      fortune: 'En attente',
+      identite: 'Sans indicatif',
+      reputation: 'I — Neutre',
     },
 
     ressources: {

--- a/src/game/donneesInitiales.js
+++ b/src/game/donneesInitiales.js
@@ -32,9 +32,16 @@ export function creerEtatInitialJeu() {
 
   return {
     meta: {
-      version: '0.3.14',
+      version: '0.3.15',
       auteur: 'Kaemyll',
       annee: 2026,
+    },
+
+    joueur: {
+      identite: 'À renseigner',
+      statut: 'Indépendant',
+      reputation: 'Inconnue',
+      fortune: 'En attente',
     },
 
     ressources: {


### PR DESCRIPTION
## Objectif
Rationaliser l’affichage du carburant dans l’interface en le retirant du panneau Ressources pour l’intégrer au panneau Vaisseau avec une jauge visuelle.

## Réalisations
- suppression de la ligne `Carburant` dans le panneau Ressources
- ajout d’un bloc `Carburant` dans le panneau Vaisseau
- affichage du carburant sous forme de jauge visuelle
- conservation de l’information chiffrée `actuel / max`
- ajout d’un état visuel synthétique :
  - Réserve correcte
  - Réserve basse
  - Réserve critique
- correction de la source de lecture pour utiliser le carburant courant réellement alimenté par l’état du jeu

## Résultat
- le panneau Ressources est allégé
- le panneau Vaisseau centralise mieux les informations techniques
- le carburant devient plus lisible visuellement
- l’interface cockpit gagne en cohérence

## Note
Un ticket complémentaire a été créé (#129) pour rapatrier ultérieurement la logique du carburant courant dans le vaisseau actif et les vaisseaux possédés, afin d’aligner complètement le modèle de données avec l’interface.