### PR TITLE
v0.3.15-122 : feat(ui) : déplacement du carburant dans le panneau Vaisseau avec jauge

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -346,7 +346,11 @@ onUnmounted(() => {
                     :secteur-courant="etat.secteurCourant"
                 />
 
-                <ShipPanel :vaisseau="etat.vaisseau" :industrie="etat.industrie" />
+                <ShipPanel
+                    :vaisseau="etat.vaisseau"
+                    :industrie="etat.industrie"
+                    :ressources="etat.ressources"
+                />
 
                 <NavigationPanel
                     :secteur-courant-id="etat.secteurCourant.id"

--- a/src/assets/styles/features/ship.css
+++ b/src/assets/styles/features/ship.css
@@ -210,6 +210,106 @@
   color: rgba(210, 225, 245, 0.76);
 }
 
+/* ===== État de carburant ===== */
+
+.ship-panel-fuel-status {
+  margin: 0 0 0.65rem;
+  padding: 0.45rem 0.55rem;
+  border: 1px solid rgba(125, 184, 255, 0.08);
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.02);
+  transition:
+          border-color var(--nh-motion-duration-fast) var(--nh-motion-ease-standard),
+          background var(--nh-motion-duration-fast) var(--nh-motion-ease-standard),
+          box-shadow var(--nh-motion-duration-fast) var(--nh-motion-ease-standard);
+}
+
+.ship-panel-fuel-status-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.45rem;
+  margin-bottom: 0.25rem;
+}
+
+.ship-panel-fuel-title {
+  font-size: 0.66rem;
+  color: rgba(210, 225, 245, 0.64);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.ship-fuel-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.14rem 0.4rem;
+  border-radius: 999px;
+  font-size: 0.6rem;
+  font-weight: 700;
+  white-space: nowrap;
+  line-height: 1;
+  border: 1px solid transparent;
+  transition:
+          border-color var(--nh-motion-duration-fast) var(--nh-motion-ease-standard),
+          background var(--nh-motion-duration-fast) var(--nh-motion-ease-standard),
+          color var(--nh-motion-duration-fast) var(--nh-motion-ease-standard),
+          box-shadow var(--nh-motion-duration-fast) var(--nh-motion-ease-standard);
+}
+
+.ship-fuel-badge--nominal {
+  color: #bfe7ff;
+  background: rgba(58, 112, 168, 0.18);
+  border-color: rgba(90, 158, 224, 0.28);
+}
+
+.ship-fuel-badge--degrade {
+  color: #f5d7a1;
+  background: rgba(168, 104, 32, 0.18);
+  border-color: rgba(214, 146, 58, 0.28);
+}
+
+.ship-fuel-badge--critique {
+  color: #ffb8b8;
+  background: rgba(150, 44, 44, 0.2);
+  border-color: rgba(224, 90, 90, 0.32);
+}
+
+.ship-panel-fuel-bar {
+  width: 100%;
+  height: 5px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.ship-panel-fuel-bar-fill {
+  height: 100%;
+  border-radius: 999px;
+  transition: width var(--nh-motion-duration-medium) var(--nh-motion-ease-standard);
+}
+
+.ship-panel-fuel-bar-fill.ship-fuel-badge--nominal {
+  background: linear-gradient(90deg, rgba(90, 158, 224, 0.72) 0%, rgba(138, 204, 255, 0.96) 100%);
+}
+
+.ship-panel-fuel-bar-fill.ship-fuel-badge--degrade {
+  background: linear-gradient(90deg, rgba(214, 146, 58, 0.7) 0%, rgba(245, 215, 161, 0.95) 100%);
+}
+
+.ship-panel-fuel-bar-fill.ship-fuel-badge--critique {
+  background: linear-gradient(90deg, rgba(170, 60, 60, 0.7) 0%, rgba(255, 184, 184, 0.95) 100%);
+}
+
+.ship-panel-fuel-meta {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin: 0.22rem 0 0;
+  font-size: 0.7rem;
+  color: rgba(210, 225, 245, 0.76);
+}
+
 /* ===== Métriques ===== */
 
 .ship-panel-metrics {

--- a/src/components/ResourcePanel.vue
+++ b/src/components/ResourcePanel.vue
@@ -2,35 +2,34 @@
 import { donneesMinerais } from '../game/dataMinerais'
 
 defineProps({
-  ressources: {
-    type: Object,
-    required: true,
-  },
-  vaisseau: {
-    type: Object,
-    required: true,
-  },
-  secteurCourant: {
-    type: Object,
-    required: true,
-  },
+    ressources: {
+        type: Object,
+        required: true,
+    },
+    vaisseau: {
+        type: Object,
+        required: true,
+    },
+    secteurCourant: {
+        type: Object,
+        required: true,
+    },
 })
 </script>
 
 <template>
-  <section class="panel">
-    <h2>◈ Ressources</h2>
-    <p>Carburant : {{ ressources.carburant }} / {{ vaisseau.carburantMax }}</p>
+    <section class="panel">
+        <h2>◈ Ressources</h2>
 
-    <h3>Contenu minéral de la soute</h3>
-    <ul class="resource-list resource-list-compact resource-list-mineraux">
-      <li v-for="minerai in donneesMinerais" :key="minerai.id">
+        <h3>Contenu minéral de la soute</h3>
+        <ul class="resource-list resource-list-compact resource-list-mineraux">
+            <li v-for="minerai in donneesMinerais" :key="minerai.id">
         <span class="resource-inline">
           <span class="resource-icon">{{ minerai.icone }}</span>
           <span class="resource-name">{{ minerai.abreviation }}</span>
         </span>
-        <span class="resource-value">{{ ressources.minerais[minerai.id] || 0 }}</span>
-      </li>
-    </ul>
-  </section>
+                <span class="resource-value">{{ ressources.minerais[minerai.id] || 0 }}</span>
+            </li>
+        </ul>
+    </section>
 </template>

--- a/src/components/ShipPanel.vue
+++ b/src/components/ShipPanel.vue
@@ -1,7 +1,5 @@
 <script setup>
 import { computed } from 'vue'
-import { recupererEtatCoque } from '../game/systemeCoque'
-import { recupererEtatVisuelCoque } from '../game/systemeEtatsVisuels'
 
 const props = defineProps({
     vaisseau: {
@@ -12,55 +10,102 @@ const props = defineProps({
         type: Object,
         required: true,
     },
+    ressources: {
+        type: Object,
+        required: true,
+    },
 })
 
 const roleLabel = computed(() => {
-    if (props.vaisseau?.role === 'mineur_leger') return 'Mineur léger'
-    if (props.vaisseau?.role === 'mineur_lourd') return 'Mineur lourd'
-    if (props.vaisseau?.role === 'mineur_renforce') return 'Mineur renforcé'
-    if (props.vaisseau?.role === 'transporteur_marchand') return 'Transporteur marchand'
-    return 'Châssis polyvalent'
+    switch (props.vaisseau.role) {
+        case 'mineur_leger':
+            return 'Mineur léger'
+        case 'mineur_renforce':
+            return 'Mineur renforcé'
+        case 'mineur_lourd':
+            return 'Mineur lourd'
+        case 'transporteur_marchand':
+            return 'Transporteur marchand'
+        default:
+            return 'Vaisseau'
+    }
 })
 
-const accrocheRole = computed(() => {
-    if (props.vaisseau?.role === 'transporteur_marchand') {
-        return 'Conçu pour le fret et les rotations commerciales.'
+const roleClass = computed(() => {
+    switch (props.vaisseau.role) {
+        case 'mineur_leger':
+            return 'ship-role-badge--light'
+        case 'mineur_renforce':
+            return 'ship-role-badge--reinforced'
+        case 'mineur_lourd':
+            return 'ship-role-badge--heavy'
+        case 'transporteur_marchand':
+            return 'ship-role-badge--trade'
+        default:
+            return 'ship-role-badge--light'
     }
-
-    if (props.vaisseau?.role === 'mineur_lourd') {
-        return 'Pensé pour l’extraction soutenue et le rendement.'
-    }
-
-    if (props.vaisseau?.role === 'mineur_renforce') {
-        return 'Prévu pour l’exploitation en zones plus exigeantes.'
-    }
-
-    return 'Châssis utilitaire d’extraction légère.'
 })
 
-const badgeRoleClasse = computed(() => {
-    if (props.vaisseau?.role === 'transporteur_marchand') {
-        return 'ship-role-badge ship-role-badge--trade'
-    }
+const descriptionVaisseau = computed(() => props.vaisseau.description || 'Vaisseau opérationnel.')
 
-    if (props.vaisseau?.role === 'mineur_lourd') {
-        return 'ship-role-badge ship-role-badge--heavy'
-    }
-
-    if (props.vaisseau?.role === 'mineur_renforce') {
-        return 'ship-role-badge ship-role-badge--reinforced'
-    }
-
-    return 'ship-role-badge ship-role-badge--light'
+const coquePourcentage = computed(() => {
+    if (!props.vaisseau.coqueMax) return 0
+    return Math.max(0, Math.min(100, Math.round((props.vaisseau.coque / props.vaisseau.coqueMax) * 100)))
 })
 
-const infosCoque = computed(() =>
-    recupererEtatCoque(props.vaisseau?.coque ?? 0, props.vaisseau?.coqueMax ?? 0),
-)
+const etatCoque = computed(() => {
+    const pourcentage = coquePourcentage.value
 
-const etatVisuelCoque = computed(() => recupererEtatVisuelCoque(infosCoque.value.code))
+    if (pourcentage <= 0) {
+        return {
+            libelle: 'Hors service',
+            classeCss: 'ship-hull-badge--hors-service',
+        }
+    }
 
-const largeurBarreCoque = computed(() => `${infosCoque.value.pourcentage}%`)
+    if (pourcentage <= 39) {
+        return {
+            libelle: 'Critique',
+            classeCss: 'ship-hull-badge--critique',
+        }
+    }
+
+    if (pourcentage <= 74) {
+        return {
+            libelle: 'Dégradée',
+            classeCss: 'ship-hull-badge--degradee',
+        }
+    }
+
+    return {
+        libelle: 'Nominale',
+        classeCss: 'ship-hull-badge--nominale',
+    }
+})
+
+const carburantActuel = computed(() => Number(props.ressources?.carburant) || 0)
+
+const carburantPourcentage = computed(() => {
+    if (!props.vaisseau.carburantMax) return 0
+    return Math.max(
+        0,
+        Math.min(100, Math.round((carburantActuel.value / props.vaisseau.carburantMax) * 100)),
+    )
+})
+
+const carburantEtatClass = computed(() => {
+    if (carburantPourcentage.value <= 15) return 'ship-fuel-badge--critique'
+    if (carburantPourcentage.value <= 40) return 'ship-fuel-badge--degrade'
+    return 'ship-fuel-badge--nominal'
+})
+
+const carburantEtatLibelle = computed(() => {
+    if (carburantPourcentage.value <= 15) return 'Réserve critique'
+    if (carburantPourcentage.value <= 40) return 'Réserve basse'
+    return 'Réserve correcte'
+})
+
+const nombreDronesActifs = computed(() => props.industrie?.drones?.length || 0)
 </script>
 
 <template>
@@ -69,53 +114,75 @@ const largeurBarreCoque = computed(() => `${infosCoque.value.pourcentage}%`)
             <div class="ship-panel-title-block">
                 <h2>⛭ Vaisseau</h2>
                 <p class="ship-panel-subtitle">
-          <span class="ship-panel-ship-group">
-            <span class="ship-panel-ship-name">{{ vaisseau.nom }}</span>
-            <span class="ship-panel-separator"> — </span>
-          </span>
+                    <span class="ship-panel-ship-name">{{ vaisseau.nom }}</span>
+                    <span class="ship-panel-separator">—</span>
                     <span class="ship-panel-builder">{{ vaisseau.constructeur }}</span>
                 </p>
             </div>
 
-            <span :class="badgeRoleClasse">
+            <span class="ship-role-badge" :class="roleClass">
         {{ roleLabel }}
       </span>
         </div>
 
-        <p class="ship-panel-role-line">
-            {{ accrocheRole }}
-        </p>
+        <p class="ship-panel-role-line">{{ descriptionVaisseau }}</p>
 
         <div class="ship-panel-hull-status ship-panel-hull-status--compact">
             <div class="ship-panel-hull-status-head">
                 <span class="ship-panel-hull-title">Intégrité de coque</span>
-                <span :class="etatVisuelCoque.classeBadge">{{ etatVisuelCoque.label }}</span>
+                <span class="ship-hull-badge" :class="etatCoque.classeCss">
+          {{ etatCoque.libelle }}
+        </span>
             </div>
 
             <div class="ship-panel-hull-bar">
                 <div
                     class="ship-panel-hull-bar-fill"
-                    :class="etatVisuelCoque.classeBarre"
-                    :style="{ width: largeurBarreCoque }"
-                ></div>
+                    :class="etatCoque.classeCss"
+                    :style="{ width: `${coquePourcentage}%` }"
+                />
             </div>
 
-            <p class="ship-panel-hull-meta">
+            <div class="ship-panel-hull-meta">
                 <span>{{ vaisseau.coque }} / {{ vaisseau.coqueMax }}</span>
-                <span>{{ infosCoque.pourcentage }}%</span>
-            </p>
+                <span>{{ coquePourcentage }}%</span>
+            </div>
+        </div>
+
+        <div class="ship-panel-fuel-status">
+            <div class="ship-panel-fuel-status-head">
+                <span class="ship-panel-fuel-title">Carburant</span>
+                <span class="ship-fuel-badge" :class="carburantEtatClass">
+          {{ carburantPourcentage }}%
+        </span>
+            </div>
+
+            <div class="ship-panel-fuel-bar">
+                <div
+                    class="ship-panel-fuel-bar-fill"
+                    :class="carburantEtatClass"
+                    :style="{ width: `${carburantPourcentage}%` }"
+                />
+            </div>
+
+            <div class="ship-panel-fuel-meta">
+                <span>{{ carburantActuel }} / {{ vaisseau.carburantMax }}</span>
+                <span>{{ carburantEtatLibelle }}</span>
+            </div>
         </div>
 
         <div class="ship-panel-metrics ship-panel-metrics--three-cols">
             <p>
-                <span>Soute</span><strong>{{ vaisseau.soute }} / {{ vaisseau.souteMax }}</strong>
+                <span>Soute</span>
+                <strong>{{ vaisseau.soute }} / {{ vaisseau.souteMax }}</strong>
             </p>
             <p>
-                <span>Canon minier</span><strong>{{ vaisseau.puissanceMiniere }}</strong>
+                <span>Canon minier</span>
+                <strong>{{ vaisseau.puissanceMiniere }}</strong>
             </p>
             <p>
-        <span>Drones</span
-        ><strong>{{ industrie.drones.length }} / {{ vaisseau.dronesMiniersMax }}</strong>
+                <span>Drones</span>
+                <strong>{{ nombreDronesActifs }} / {{ vaisseau.dronesMiniersMax }}</strong>
             </p>
         </div>
     </section>


### PR DESCRIPTION
## Objectif
Rationaliser l’affichage du carburant dans l’interface en le retirant du panneau Ressources pour l’intégrer au panneau Vaisseau avec une jauge visuelle.

## Réalisations
- suppression de la ligne `Carburant` dans le panneau Ressources
- ajout d’un bloc `Carburant` dans le panneau Vaisseau
- affichage du carburant sous forme de jauge visuelle
- conservation de l’information chiffrée `actuel / max`
- ajout d’un état visuel synthétique :
  - Réserve correcte
  - Réserve basse
  - Réserve critique
- correction de la source de lecture pour utiliser le carburant courant réellement alimenté par l’état du jeu

## Résultat
- le panneau Ressources est allégé
- le panneau Vaisseau centralise mieux les informations techniques
- le carburant devient plus lisible visuellement
- l’interface cockpit gagne en cohérence

## Note
Un ticket complémentaire a été créé (#129) pour rapatrier ultérieurement la logique du carburant courant dans le vaisseau actif et les vaisseaux possédés, afin d’aligner complètement le modèle de données avec l’interface.