### PR TITLE
v0.3.15-124 : feat(gameplay) : ajout du service d’assurance dans les services de station

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -34,7 +34,11 @@ import { allerEnZoneOperations, retourALaStation } from './game/systemeLocalisat
 import { scannerAmasMinier } from './game/systemeExploration'
 import { donneesSecteurs } from './game/dataSecteurs'
 import { demarrerBoucleJeu, arreterBoucleJeu } from './game/systemeTick'
-import { acheterVaisseau, changerVaisseauActif } from './game/systemeVaisseaux'
+import {
+    acheterVaisseau,
+    changerVaisseauActif,
+    souscrireAssuranceVaisseauActif,
+} from './game/systemeVaisseaux'
 
 const etat = reactive({})
 
@@ -90,6 +94,7 @@ function normaliserSousModeStation() {
     if (ui.sousModeStation === 'commerce' && services.commerce) return
     if (ui.sousModeStation === 'ravitaillement' && services.ravitaillement) return
     if (ui.sousModeStation === 'atelier' && services.atelier) return
+    if (ui.sousModeStation === 'assurance') return
 
     ui.sousModeStation = 'hangar'
 }
@@ -192,6 +197,12 @@ function gererReparationVaisseau() {
 
 function gererReparationPartielleVaisseau() {
     reparerPartiellementVaisseauActif()
+    sauvegarderJeu()
+    synchroniserEtat()
+}
+
+function gererSouscriptionAssurance(niveauAssurance) {
+    souscrireAssuranceVaisseauActif(niveauAssurance)
     sauvegarderJeu()
     synchroniserEtat()
 }
@@ -396,6 +407,7 @@ onUnmounted(() => {
                         @acheter-drone="gererAchatDrone"
                         @reparer-vaisseau="gererReparationVaisseau"
                         @reparer-partiellement-vaisseau="gererReparationPartielleVaisseau"
+                        @souscrire-assurance="gererSouscriptionAssurance"
                         @retour-station="gererRetourStation"
                         @aller-operations="gererAllerOperations"
                     >

--- a/src/assets/styles/features/station-services.css
+++ b/src/assets/styles/features/station-services.css
@@ -90,6 +90,10 @@
   border-color: rgba(114, 167, 214, 0.14);
 }
 
+.station-service-card-insurance {
+  border-color: rgba(182, 147, 235, 0.16);
+}
+
 .station-service-card-workshop {
   min-height: 0;
   display: flex;
@@ -137,6 +141,11 @@
 
 .station-service-grid--atelier-devis-5 {
   grid-template-columns: repeat(5, minmax(0, 1fr));
+}
+
+.station-service-grid--insurance {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  margin-bottom: 6px;
 }
 
 .station-service-metric {
@@ -203,6 +212,94 @@
   align-items: center;
   gap: 8px;
   margin-top: 4px;
+}
+
+/* ===== Bloc assurance ===== */
+
+.station-insurance-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.station-insurance-card {
+  padding: 10px;
+  border: 1px solid rgba(125, 184, 255, 0.1);
+  border-radius: 10px;
+  background: rgba(0, 0, 0, 0.12);
+  transition:
+          border-color var(--nh-motion-duration-fast) var(--nh-motion-ease-standard),
+          background var(--nh-motion-duration-fast) var(--nh-motion-ease-standard),
+          box-shadow var(--nh-motion-duration-fast) var(--nh-motion-ease-standard);
+}
+
+.station-insurance-card--active {
+  border-color: rgba(125, 184, 255, 0.22);
+  background: rgba(125, 184, 255, 0.05);
+  box-shadow: inset 0 0 0 1px rgba(125, 184, 255, 0.04);
+}
+
+.station-insurance-card-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.station-insurance-card h4 {
+  margin: 0 0 8px;
+  font-size: 0.86rem;
+  line-height: 1.2;
+}
+
+.station-insurance-current {
+  font-size: 0.72rem;
+  opacity: 0.78;
+}
+
+.station-insurance-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.22rem;
+  padding: 0.18rem 0.48rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  font-size: 0.68rem;
+  font-weight: 700;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.station-insurance-badge--none {
+  background: rgba(120, 128, 138, 0.12);
+  color: #9aa6b3;
+  border-color: rgba(160, 172, 186, 0.2);
+}
+
+.station-insurance-badge--tiers {
+  background: rgba(170, 52, 52, 0.14);
+  color: #ff9c9c;
+  border-color: rgba(224, 90, 90, 0.24);
+}
+
+.station-insurance-badge--standard {
+  background: rgba(168, 124, 32, 0.14);
+  color: #ffd97b;
+  border-color: rgba(214, 146, 58, 0.24);
+}
+
+.station-insurance-badge--premium {
+  background: rgba(44, 122, 78, 0.16);
+  color: #9df0be;
+  border-color: rgba(86, 196, 124, 0.24);
+}
+
+.station-insurance-badge--elite {
+  background: rgba(116, 52, 170, 0.16);
+  color: #d6a9ff;
+  border-color: rgba(176, 104, 255, 0.26);
 }
 
 /* ===== Listes station ===== */

--- a/src/components/StationServicesPanel.vue
+++ b/src/components/StationServicesPanel.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { computed } from 'vue'
 import { donneesSecteurs } from '../game/dataSecteurs'
+import { donneesVaisseaux } from '../game/dataVaisseaux'
 import {
     calculerCoursLocauxPourStation,
     calculerTauxTaxePourSecurite,
@@ -51,6 +52,7 @@ const emit = defineEmits([
     'acheter-drone',
     'reparer-vaisseau',
     'reparer-partiellement-vaisseau',
+    'souscrire-assurance',
     'aller-operations',
     'retour-station',
 ])
@@ -117,6 +119,73 @@ const reparationPartielleAbordable = computed(
 )
 
 const tarifAtelier = computed(() => `${COUT_REPARATION_PAR_POINT} cr / pt`)
+
+const modeleVaisseau = computed(() =>
+    donneesVaisseaux.find((modele) => modele.id === props.vaisseau.modeleId) || null,
+)
+
+const valeurMarchandeVaisseau = computed(() => Number(modeleVaisseau.value?.prix || 0))
+
+const assuranceActuelle = computed(() => props.vaisseau.assuranceNiveau || 'aucune')
+
+const offresAssurance = computed(() => {
+    const base = valeurMarchandeVaisseau.value
+
+    const arrondir = (valeur) => Math.max(0, Math.round(valeur))
+
+    return [
+        {
+            id: 'aucune',
+            code: 'Auc',
+            nom: 'Aucune couverture',
+            remboursement: '0%',
+            cout: 0,
+            description: 'Aucun contrat actif. Aucun remboursement en cas de perte.',
+            badgeClass: 'station-assurance-badge--none',
+        },
+        {
+            id: 'tiers',
+            code: 'Trs',
+            nom: 'Contrat au tiers',
+            remboursement: '33%',
+            cout: arrondir(base * 0.04),
+            description: 'Couverture minimale, adaptée aux opérations à faible coût.',
+            badgeClass: 'station-assurance-badge--tiers',
+        },
+        {
+            id: 'standard',
+            code: 'Std',
+            nom: 'Contrat standard',
+            remboursement: '66%',
+            cout: arrondir(base * 0.07),
+            description: 'Couverture intermédiaire pour un usage régulier en secteur civil.',
+            badgeClass: 'station-assurance-badge--standard',
+        },
+        {
+            id: 'premium',
+            code: 'Prm',
+            nom: 'Contrat premium',
+            remboursement: '100%',
+            cout: arrondir(base * 0.11),
+            description: 'Couverture intégrale. Les restrictions de réputation seront appliquées plus tard.',
+            badgeClass: 'station-assurance-badge--premium',
+        },
+        {
+            id: 'elite',
+            code: 'Elt',
+            nom: 'Contrat élite',
+            remboursement: '125%',
+            cout: arrondir(base * 0.16),
+            description:
+                'Couverture renforcée. Les conditions avancées de réputation seront appliquées ultérieurement.',
+            badgeClass: 'station-assurance-badge--elite',
+        },
+    ]
+})
+
+const offreAssuranceActuelle = computed(
+    () => offresAssurance.value.find((offre) => offre.id === assuranceActuelle.value) || offresAssurance.value[0],
+)
 
 function recupererQuantiteEnSoute(idMinerai) {
     return props.ressources?.minerais?.[idMinerai] || 0
@@ -205,6 +274,15 @@ function vendreMineraiMax(minerai) {
             </button>
 
             <button
+                :class="{ 'is-active': sousModeStation === 'assurance' }"
+                class="action-button-with-icon"
+                @click="emit('changer-sous-mode-station', 'assurance')"
+            >
+                <span class="button-icon" aria-hidden="true">★</span>
+                <span>Assurance</span>
+            </button>
+
+            <button
                 v-if="station.services.atelier"
                 :class="{ 'is-active': sousModeStation === 'atelier' }"
                 class="action-button-with-icon"
@@ -223,8 +301,7 @@ function vendreMineraiMax(minerai) {
                 </div>
 
                 <p class="station-service-description">
-                    Les services de station ne sont accessibles qu’une fois revenu et amarré à la station
-                    locale.
+                    Les services de station ne sont accessibles qu’une fois revenu et amarré à la station locale.
                 </p>
 
                 <div class="action-group">
@@ -334,9 +411,7 @@ function vendreMineraiMax(minerai) {
                         </div>
 
                         <div class="market-rate-row market-rate-row--bottom">
-              <span class="market-rate-average">
-                En soute : {{ recupererQuantiteEnSoute(minerai.id) }}
-              </span>
+                            <span class="market-rate-average">En soute : {{ recupererQuantiteEnSoute(minerai.id) }}</span>
                         </div>
 
                         <div class="action-group-market">
@@ -431,6 +506,98 @@ function vendreMineraiMax(minerai) {
             </div>
 
             <div
+                v-else-if="sousModeStation === 'assurance'"
+                class="station-service-card station-service-card-insurance station-service-card--scrollable"
+            >
+                <div class="station-service-card-header">
+                    <h3>★ Service d’assurance</h3>
+                    <span class="station-service-badge">Actif</span>
+                </div>
+
+                <div class="station-service-grid">
+                    <div class="station-service-metric">
+                        <span class="station-service-label">Contrat actuel</span>
+                        <strong>{{ offreAssuranceActuelle.nom }}</strong>
+                    </div>
+
+                    <div class="station-service-metric">
+                        <span class="station-service-label">Remboursement</span>
+                        <strong>{{ offreAssuranceActuelle.remboursement }}</strong>
+                    </div>
+
+                    <div class="station-service-metric">
+                        <span class="station-service-label">Vaisseau couvert</span>
+                        <strong>{{ vaisseau.nom }}</strong>
+                    </div>
+
+                    <div class="station-service-metric">
+                        <span class="station-service-label">Valeur marchande</span>
+                        <strong>{{ valeurMarchandeVaisseau }} cr</strong>
+                    </div>
+                </div>
+
+                <p class="station-service-description">
+                    Souscription ou mise à niveau du contrat d’assurance du vaisseau actif. Les règles de
+                    durée, de renouvellement et les restrictions de réputation seront étendues dans des tickets dédiés.
+                </p>
+
+                <div class="station-insurance-grid">
+                    <article
+                        v-for="offre in offresAssurance"
+                        :key="offre.id"
+                        class="station-insurance-card"
+                        :class="{
+              'station-insurance-card--active': assuranceActuelle === offre.id,
+            }"
+                    >
+                        <div class="station-insurance-card-head">
+              <span class="station-insurance-badge" :class="offre.badgeClass">
+                <span aria-hidden="true">★</span>
+                <span>{{ offre.code }}</span>
+              </span>
+
+                            <span v-if="assuranceActuelle === offre.id" class="station-insurance-current">
+                En cours
+              </span>
+                        </div>
+
+                        <h4>{{ offre.nom }}</h4>
+
+                        <div class="station-service-grid station-service-grid--insurance">
+                            <div class="station-service-metric station-service-metric--compact">
+                                <span class="station-service-label">Remboursement</span>
+                                <strong>{{ offre.remboursement }}</strong>
+                            </div>
+
+                            <div class="station-service-metric station-service-metric--compact">
+                                <span class="station-service-label">Coût</span>
+                                <strong>{{ offre.cout }} cr</strong>
+                            </div>
+                        </div>
+
+                        <p class="station-service-description station-service-description--compact">
+                            {{ offre.description }}
+                        </p>
+
+                        <button
+                            class="action-button-with-icon"
+                            :disabled="assuranceActuelle === offre.id || ressources.credits < offre.cout"
+                            @click="emit('souscrire-assurance', offre.id)"
+                        >
+                            <span class="button-icon" aria-hidden="true">★</span>
+                            <span>
+                {{ assuranceActuelle === offre.id ? 'Contrat actif' : 'Souscrire' }}
+              </span>
+                        </button>
+                    </article>
+                </div>
+
+                <p class="panel-note">
+                    Les niveaux premium et élite seront plus tard soumis à des conditions de réputation.
+                </p>
+            </div>
+
+            <div
                 v-else-if="sousModeStation === 'atelier'"
                 class="station-service-card station-service-card-workshop"
             >
@@ -439,7 +606,9 @@ function vendreMineraiMax(minerai) {
                     <span class="station-service-badge">Actif</span>
                 </div>
 
-                <div class="station-service-grid station-service-grid--atelier-devis station-service-grid--atelier-devis-5">
+                <div
+                    class="station-service-grid station-service-grid--atelier-devis station-service-grid--atelier-devis-5"
+                >
                     <div class="station-service-metric station-service-metric--compact">
                         <span class="station-service-label">Coque</span>
                         <strong>{{ vaisseau.coque }} / {{ vaisseau.coqueMax }}</strong>
@@ -511,20 +680,18 @@ function vendreMineraiMax(minerai) {
                 </p>
 
                 <div class="action-group action-group--atelier-support">
-                    <div
-                        class="station-service-metric station-service-metric--compact station-service-metric--support"
-                    >
+                    <div class="station-service-metric station-service-metric--compact station-service-metric--support">
                         <span class="station-service-label">Drone minier</span>
                         <strong>{{ coutDroneMinier }} cr / unité</strong>
                     </div>
 
                     <button class="action-button-with-icon" @click="emit('acheter-drone')">
-                        <span class="button-icon" aria-hidden="true">⇪</span>
-                        <span>Acheter un drone minier — {{ coutDroneMinier }} crédits</span>
+                        <span class="button-icon" aria-hidden="true">⛏</span>
+                        <span>Acheter un drone</span>
                     </button>
                 </div>
 
-                <div class="station-upgrade-shell">
+                <div class="station-service-mode station-service-mode--fill">
                     <slot name="atelier" />
                 </div>
             </div>

--- a/src/game/systemeVaisseaux.js
+++ b/src/game/systemeVaisseaux.js
@@ -26,6 +26,21 @@ function bornerValeur(valeur, minimum, maximum) {
   return Math.min(Math.max(valeur, minimum), maximum)
 }
 
+function recupererLibelleAssurance(niveau) {
+  switch (niveau) {
+    case 'tiers':
+      return 'au tiers'
+    case 'standard':
+      return 'standard'
+    case 'premium':
+      return 'premium'
+    case 'elite':
+      return 'élite'
+    default:
+      return 'aucune'
+  }
+}
+
 export function creerInstanceVaisseauDepuisModele(modeleId, suffixe = '001') {
   const modele = donneesVaisseaux.find((vaisseau) => vaisseau.id === modeleId)
 
@@ -47,6 +62,7 @@ export function creerInstanceVaisseauDepuisModele(modeleId, suffixe = '001') {
     dronesMiniersMax: modele.dronesMiniersMax,
     carburant: modele.carburantMax,
     carburantMax: modele.carburantMax,
+    assuranceNiveau: 'aucune',
     scanner: structuredClone(modele.scanner || {}),
     ameliorations: structuredClone(modele.ameliorations || []),
     ameliorationsMax: structuredClone(modele.ameliorationsMax || {}),
@@ -59,8 +75,8 @@ export function normaliserVaisseauPossede(vaisseau) {
   }
 
   const modele = donneesVaisseaux.find(
-    (modeleVaisseau) =>
-      modeleVaisseau.id === vaisseau.modeleId || modeleVaisseau.id === vaisseau.id,
+      (modeleVaisseau) =>
+          modeleVaisseau.id === vaisseau.modeleId || modeleVaisseau.id === vaisseau.id,
   )
 
   if (!modele) {
@@ -85,6 +101,7 @@ export function normaliserVaisseauPossede(vaisseau) {
     dronesMiniersMax: Number(vaisseau.dronesMiniersMax ?? modele.dronesMiniersMax ?? 0),
     carburant: bornerValeur(Number(vaisseau.carburant ?? carburantMax), 0, carburantMax),
     carburantMax,
+    assuranceNiveau: vaisseau.assuranceNiveau || 'aucune',
     scanner: structuredClone(vaisseau.scanner || modele.scanner || {}),
     ameliorations: structuredClone(vaisseau.ameliorations || modele.ameliorations || []),
     ameliorationsMax: structuredClone(vaisseau.ameliorationsMax || modele.ameliorationsMax || {}),
@@ -127,38 +144,40 @@ export function synchroniserFlotteDepuisVaisseauActif(etat = recupererEtatJeu())
 
   vaisseauActif.coqueMax = Number(etat.vaisseau.coqueMax ?? vaisseauActif.coqueMax)
   vaisseauActif.coque = bornerValeur(
-    Number(etat.vaisseau.coque ?? vaisseauActif.coque),
-    0,
-    vaisseauActif.coqueMax,
+      Number(etat.vaisseau.coque ?? vaisseauActif.coque),
+      0,
+      vaisseauActif.coqueMax,
   )
 
   vaisseauActif.souteMax = Number(etat.vaisseau.souteMax ?? vaisseauActif.souteMax)
   vaisseauActif.soute = bornerValeur(
-    Number(etat.vaisseau.soute ?? vaisseauActif.soute),
-    0,
-    vaisseauActif.souteMax,
+      Number(etat.vaisseau.soute ?? vaisseauActif.soute),
+      0,
+      vaisseauActif.souteMax,
   )
 
   vaisseauActif.puissanceMiniere = Number(
-    etat.vaisseau.puissanceMiniere ?? vaisseauActif.puissanceMiniere,
+      etat.vaisseau.puissanceMiniere ?? vaisseauActif.puissanceMiniere,
   )
   vaisseauActif.dronesMiniersMax = Number(
-    etat.vaisseau.dronesMiniersMax ?? vaisseauActif.dronesMiniersMax,
+      etat.vaisseau.dronesMiniersMax ?? vaisseauActif.dronesMiniersMax,
   )
 
   vaisseauActif.carburantMax = Number(etat.vaisseau.carburantMax ?? vaisseauActif.carburantMax)
   vaisseauActif.carburant = bornerValeur(
-    Number(etat.ressources.carburant ?? vaisseauActif.carburant),
-    0,
-    vaisseauActif.carburantMax,
+      Number(etat.ressources.carburant ?? vaisseauActif.carburant),
+      0,
+      vaisseauActif.carburantMax,
   )
+
+  vaisseauActif.assuranceNiveau = etat.vaisseau.assuranceNiveau || vaisseauActif.assuranceNiveau || 'aucune'
 
   vaisseauActif.scanner = structuredClone(etat.vaisseau.scanner || vaisseauActif.scanner || {})
   vaisseauActif.ameliorations = structuredClone(
-    etat.vaisseau.ameliorations || vaisseauActif.ameliorations || [],
+      etat.vaisseau.ameliorations || vaisseauActif.ameliorations || [],
   )
   vaisseauActif.ameliorationsMax = structuredClone(
-    etat.vaisseau.ameliorationsMax || vaisseauActif.ameliorationsMax || {},
+      etat.vaisseau.ameliorationsMax || vaisseauActif.ameliorationsMax || {},
   )
 }
 
@@ -182,6 +201,7 @@ export function synchroniserVaisseauActifDansEtat(etat = recupererEtatJeu()) {
     puissanceMiniere: vaisseauActif.puissanceMiniere,
     dronesMiniersMax: vaisseauActif.dronesMiniersMax,
     carburantMax: vaisseauActif.carburantMax,
+    assuranceNiveau: vaisseauActif.assuranceNiveau || 'aucune',
     scanner: structuredClone(vaisseauActif.scanner || {}),
     ameliorations: structuredClone(vaisseauActif.ameliorations || []),
     ameliorationsMax: structuredClone(vaisseauActif.ameliorationsMax || {}),
@@ -199,25 +219,27 @@ export function hydraterEtatVaisseauxApresChargement(etat = recupererEtatJeu()) 
     vaisseauHydrate.soute = etat.vaisseau?.soute ?? vaisseauHydrate.soute
     vaisseauHydrate.souteMax = etat.vaisseau?.souteMax ?? vaisseauHydrate.souteMax
     vaisseauHydrate.puissanceMiniere =
-      etat.vaisseau?.puissanceMiniere ?? vaisseauHydrate.puissanceMiniere
+        etat.vaisseau?.puissanceMiniere ?? vaisseauHydrate.puissanceMiniere
     vaisseauHydrate.dronesMiniersMax =
-      etat.vaisseau?.dronesMiniersMax ?? vaisseauHydrate.dronesMiniersMax
+        etat.vaisseau?.dronesMiniersMax ?? vaisseauHydrate.dronesMiniersMax
     vaisseauHydrate.carburant = etat.ressources?.carburant ?? vaisseauHydrate.carburant
     vaisseauHydrate.carburantMax = etat.vaisseau?.carburantMax ?? vaisseauHydrate.carburantMax
+    vaisseauHydrate.assuranceNiveau =
+        etat.vaisseau?.assuranceNiveau ?? vaisseauHydrate.assuranceNiveau
     vaisseauHydrate.scanner = structuredClone(etat.vaisseau?.scanner || vaisseauHydrate.scanner)
     vaisseauHydrate.ameliorations = structuredClone(
-      etat.vaisseau?.ameliorations || vaisseauHydrate.ameliorations,
+        etat.vaisseau?.ameliorations || vaisseauHydrate.ameliorations,
     )
     vaisseauHydrate.ameliorationsMax = structuredClone(
-      etat.vaisseau?.ameliorationsMax || vaisseauHydrate.ameliorationsMax || {},
+        etat.vaisseau?.ameliorationsMax || vaisseauHydrate.ameliorationsMax || {},
     )
 
     etat.vaisseauxPossedes = [normaliserVaisseauPossede(vaisseauHydrate)]
     etat.vaisseauActifId = etat.vaisseauxPossedes[0].id
   } else {
     etat.vaisseauxPossedes = etat.vaisseauxPossedes
-      .map((vaisseau) => normaliserVaisseauPossede(vaisseau))
-      .filter(Boolean)
+        .map((vaisseau) => normaliserVaisseauPossede(vaisseau))
+        .filter(Boolean)
   }
 
   if (!etat.vaisseauActifId && etat.vaisseauxPossedes.length > 0) {
@@ -251,7 +273,7 @@ export function peutChangerDeVaisseau(idVaisseau, etat = recupererEtatJeu()) {
   }
 
   const vaisseauCible =
-    (etat.vaisseauxPossedes || []).find((vaisseau) => vaisseau.id === idVaisseau) || null
+      (etat.vaisseauxPossedes || []).find((vaisseau) => vaisseau.id === idVaisseau) || null
 
   if (!vaisseauCible) {
     return { ok: false, raison: 'Vaisseau cible introuvable dans le hangar.' }
@@ -296,8 +318,8 @@ export function changerVaisseauActif(idVaisseau) {
   synchroniserVaisseauActifDansEtat(etat)
 
   ajouterAuJournal(
-    `Changement de châssis effectué : ${vaisseauCible.nom} désormais actif.`,
-    'evenements',
+      `Changement de châssis effectué : ${vaisseauCible.nom} désormais actif.`,
+      'evenements',
   )
 
   return true
@@ -309,11 +331,11 @@ export function recupererCatalogueVaisseauxStation(secteurId, etat = recupererEt
   }
 
   return donneesVaisseaux
-    .filter((vaisseau) => vaisseau.id === 'hw_caravel')
-    .map((modele) => ({
-      ...modele,
-      dejaPossede: possedeDejaModele(modele.id, etat),
-    }))
+      .filter((vaisseau) => vaisseau.id === 'hw_caravel')
+      .map((modele) => ({
+        ...modele,
+        dejaPossede: possedeDejaModele(modele.id, etat),
+      }))
 }
 
 export function peutAcheterVaisseau(modeleId, etat = recupererEtatJeu()) {
@@ -357,7 +379,7 @@ export function acheterVaisseau(modeleId) {
 
   const modele = donneesVaisseaux.find((vaisseau) => vaisseau.id === modeleId)
   const exemplairesExistants = etat.vaisseauxPossedes.filter(
-    (vaisseau) => vaisseau.modeleId === modeleId,
+      (vaisseau) => vaisseau.modeleId === modeleId,
   ).length
   const suffixe = String(exemplairesExistants + 1).padStart(3, '0')
   const nouveauVaisseau = creerInstanceVaisseauDepuisModele(modeleId, suffixe)
@@ -366,8 +388,78 @@ export function acheterVaisseau(modeleId) {
   etat.vaisseauxPossedes.push(normaliserVaisseauPossede(nouveauVaisseau))
 
   ajouterAuJournal(
-    `Acquisition confirmée : ${modele.nom} ajouté au hangar pour ${modele.prix} cr.`,
-    'commerce',
+      `Acquisition confirmée : ${modele.nom} ajouté au hangar pour ${modele.prix} cr.`,
+      'commerce',
+  )
+
+  return true
+}
+
+export function peutSouscrireAssuranceVaisseauActif(niveau, etat = recupererEtatJeu()) {
+  const vaisseauActif = recupererVaisseauActif(etat)
+
+  if (!vaisseauActif) {
+    return { ok: false, raison: 'Aucun vaisseau actif disponible.' }
+  }
+
+  if (etat.positionLocale !== 'station') {
+    return { ok: false, raison: 'La souscription d’assurance est possible uniquement en station.' }
+  }
+
+  if (etat.navigation?.enVoyage) {
+    return { ok: false, raison: 'Impossible de modifier une assurance pendant un trajet.' }
+  }
+
+  const niveauxAutorises = ['aucune', 'tiers', 'standard', 'premium', 'elite']
+
+  if (!niveauxAutorises.includes(niveau)) {
+    return { ok: false, raison: 'Niveau d’assurance invalide.' }
+  }
+
+  if ((vaisseauActif.assuranceNiveau || 'aucune') === niveau) {
+    return { ok: false, raison: 'Ce contrat est déjà actif sur le vaisseau.' }
+  }
+
+  const modele = donneesVaisseaux.find((entree) => entree.id === vaisseauActif.modeleId)
+  const valeurMarchande = Number(modele?.prix || 0)
+
+  const multiplicateurs = {
+    aucune: 0,
+    tiers: 0.04,
+    standard: 0.07,
+    premium: 0.11,
+    elite: 0.16,
+  }
+
+  const cout = Math.max(0, Math.round(valeurMarchande * (multiplicateurs[niveau] || 0)))
+
+  if ((etat.ressources?.credits || 0) < cout) {
+    return { ok: false, raison: 'Crédits insuffisants pour cette formule d’assurance.' }
+  }
+
+  return { ok: true, raison: null, cout }
+}
+
+export function souscrireAssuranceVaisseauActif(niveau) {
+  const etat = recupererEtatJeu()
+  const validation = peutSouscrireAssuranceVaisseauActif(niveau, etat)
+
+  if (!validation.ok) {
+    ajouterAuJournal(validation.raison, 'commerce')
+    return false
+  }
+
+  synchroniserFlotteDepuisVaisseauActif(etat)
+
+  const vaisseauActif = recupererVaisseauActif(etat)
+  vaisseauActif.assuranceNiveau = niveau
+  etat.ressources.credits -= validation.cout
+
+  synchroniserVaisseauActifDansEtat(etat)
+
+  ajouterAuJournal(
+      `Contrat d’assurance ${recupererLibelleAssurance(niveau)} souscrit pour ${vaisseauActif.nom} (${validation.cout} cr).`,
+      'commerce',
   )
 
   return true


### PR DESCRIPTION
## Objectif
Ajouter un sous-panneau Assurance dans les services de station afin de permettre la souscription et le changement de contrat pour le vaisseau actif.

## Réalisations
- ajout d’un nouveau sous-mode `assurance` dans le panneau des services de station
- ajout d’un onglet Assurance dans les modes de station
- affichage du contrat actuel du vaisseau actif
- affichage des différentes formules disponibles :
  - Auc
  - Trs
  - Std
  - Prm
  - Elt
- affichage du taux de remboursement et du coût de chaque formule
- ajout de la logique de souscription côté `systemeVaisseaux`
- journalisation des souscriptions
- persistance du niveau d’assurance sur le vaisseau actif

## Résultat
- l’assurance n’est plus seulement visible dans le panneau Vaisseau
- elle devient désormais gérable directement depuis la station
- l’architecture est prête pour les futurs tickets :
  - durée et validité des contrats
  - restrictions de réputation
  - remboursement en cas de perte