### PR TITLE
v0.3.15-62 : feat: ajouter une animation et des sons de voyage

### DIFF
--- a/src/assets/styles/components/navigation.css
+++ b/src/assets/styles/components/navigation.css
@@ -76,39 +76,40 @@ select {
 
 .navigation-panel {
   transition:
-    border-color var(--nh-motion-duration-fast) var(--nh-motion-ease-standard),
-    background var(--nh-motion-duration-fast) var(--nh-motion-ease-standard),
-    box-shadow var(--nh-motion-duration-fast) var(--nh-motion-ease-standard);
+          border-color var(--nh-motion-duration-fast) var(--nh-motion-ease-standard),
+          background var(--nh-motion-duration-fast) var(--nh-motion-ease-standard),
+          box-shadow var(--nh-motion-duration-fast) var(--nh-motion-ease-standard);
 }
 
 .navigation-panel--active {
   border-color: rgba(92, 150, 220, 0.26);
   box-shadow:
-    inset 0 0 0 1px rgba(92, 150, 220, 0.05),
-    0 0 16px rgba(32, 74, 124, 0.1);
+          inset 0 0 0 1px rgba(92, 150, 220, 0.05),
+          0 0 16px rgba(32, 74, 124, 0.1);
 }
 
 .navigation-panel--station-context:not(.navigation-panel--in-transit) {
   background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.018) 0%, rgba(255, 255, 255, 0) 100%),
-    rgba(255, 255, 255, 0.02);
+          linear-gradient(180deg, rgba(255, 255, 255, 0.018) 0%, rgba(255, 255, 255, 0) 100%),
+          rgba(255, 255, 255, 0.02);
 }
 
 .navigation-panel--operations-context:not(.navigation-panel--in-transit) {
   border-color: rgba(186, 163, 96, 0.22);
   background:
-    linear-gradient(180deg, rgba(186, 163, 96, 0.05) 0%, rgba(255, 255, 255, 0) 100%),
-    rgba(255, 255, 255, 0.02);
+          linear-gradient(180deg, rgba(186, 163, 96, 0.05) 0%, rgba(255, 255, 255, 0) 100%),
+          rgba(255, 255, 255, 0.02);
 }
 
 .navigation-panel--in-transit {
-  border-color: rgba(92, 150, 220, 0.28);
+  border-color: rgba(92, 150, 220, 0.32);
   background:
-    linear-gradient(180deg, rgba(46, 95, 160, 0.08) 0%, rgba(255, 255, 255, 0) 100%),
-    rgba(255, 255, 255, 0.025);
+          radial-gradient(circle at 50% 0%, rgba(92, 150, 220, 0.12), transparent 52%),
+          linear-gradient(180deg, rgba(46, 95, 160, 0.1) 0%, rgba(255, 255, 255, 0) 100%),
+          rgba(255, 255, 255, 0.025);
   box-shadow:
-    inset 0 0 0 1px rgba(92, 150, 220, 0.06),
-    0 0 18px rgba(32, 74, 124, 0.12);
+          inset 0 0 0 1px rgba(92, 150, 220, 0.08),
+          0 0 22px rgba(32, 74, 124, 0.16);
 }
 
 .navigation-panel-header {
@@ -144,9 +145,9 @@ select {
 
 .navigation-select {
   transition:
-    border-color var(--nh-motion-duration-fast) var(--nh-motion-ease-standard),
-    background var(--nh-motion-duration-fast) var(--nh-motion-ease-standard),
-    box-shadow var(--nh-motion-duration-fast) var(--nh-motion-ease-standard);
+          border-color var(--nh-motion-duration-fast) var(--nh-motion-ease-standard),
+          background var(--nh-motion-duration-fast) var(--nh-motion-ease-standard),
+          box-shadow var(--nh-motion-duration-fast) var(--nh-motion-ease-standard);
 }
 
 .navigation-panel--active .navigation-select,
@@ -157,8 +158,8 @@ select {
 
 .navigation-route-meta {
   transition:
-    color var(--nh-motion-duration-fast) var(--nh-motion-ease-standard),
-    opacity var(--nh-motion-duration-fast) var(--nh-motion-ease-standard);
+          color var(--nh-motion-duration-fast) var(--nh-motion-ease-standard),
+          opacity var(--nh-motion-duration-fast) var(--nh-motion-ease-standard);
 }
 
 .navigation-panel--in-transit .navigation-route-meta,
@@ -171,4 +172,139 @@ select {
   font-style: italic;
   font-size: 0.88rem;
   opacity: 0.9;
+}
+
+/* =========================================================
+   ANIMATION DE VOYAGE
+   ---------------------------------------------------------
+   Rôle :
+   - matérialiser le transit inter-sectoriel
+   - renforcer la perception de déplacement
+   - rester lisible et non intrusif
+   ========================================================= */
+
+.navigation-transit-visual {
+  --navigation-transit-progress: 0%;
+  position: relative;
+  overflow: hidden;
+  min-height: 48px;
+  margin: 0.2rem 0 0.75rem;
+  padding: 0.72rem 0.8rem;
+  border: 1px solid rgba(92, 150, 220, 0.2);
+  border-radius: 12px;
+  background:
+          linear-gradient(90deg, rgba(92, 150, 220, 0.08), transparent 48%, rgba(92, 150, 220, 0.06)),
+          rgba(5, 15, 28, 0.42);
+  box-shadow:
+          inset 0 0 0 1px rgba(92, 150, 220, 0.05),
+          0 0 16px rgba(32, 74, 124, 0.1);
+}
+
+.navigation-transit-stars {
+  position: absolute;
+  inset: 0;
+  opacity: 0.32;
+  background:
+          linear-gradient(90deg, transparent 0%, rgba(184, 226, 255, 0.22) 50%, transparent 100%),
+          repeating-linear-gradient(
+                  90deg,
+                  rgba(125, 184, 255, 0) 0,
+                  rgba(125, 184, 255, 0) 18px,
+                  rgba(125, 184, 255, 0.26) 19px,
+                  rgba(125, 184, 255, 0) 21px
+          );
+  animation: nhTransitField 1.8s linear infinite;
+  pointer-events: none;
+}
+
+.navigation-transit-track {
+  position: relative;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.6rem;
+  min-height: 22px;
+  z-index: 1;
+}
+
+.navigation-transit-node {
+  width: 0.65rem;
+  height: 0.65rem;
+  border-radius: 999px;
+  background: rgba(184, 226, 255, 0.92);
+  box-shadow: 0 0 10px rgba(125, 184, 255, 0.42);
+}
+
+.navigation-transit-node--destination {
+  background: rgba(185, 240, 201, 0.92);
+  box-shadow: 0 0 10px rgba(86, 196, 124, 0.34);
+}
+
+.navigation-transit-line,
+.navigation-transit-progress {
+  grid-column: 2;
+  grid-row: 1;
+  height: 3px;
+  border-radius: 999px;
+}
+
+.navigation-transit-line {
+  width: 100%;
+  background: rgba(125, 184, 255, 0.14);
+}
+
+.navigation-transit-progress {
+  width: var(--navigation-transit-progress);
+  min-width: 8px;
+  max-width: 100%;
+  background: linear-gradient(90deg, rgba(92, 150, 220, 0.45), rgba(184, 226, 255, 0.96));
+  box-shadow: 0 0 10px rgba(125, 184, 255, 0.2);
+  transition: width var(--nh-motion-duration-medium) var(--nh-motion-ease-standard);
+}
+
+.navigation-transit-pulse {
+  grid-column: 2;
+  grid-row: 1;
+  justify-self: start;
+  width: 0.72rem;
+  height: 0.72rem;
+  margin-left: var(--navigation-transit-progress);
+  border-radius: 999px;
+  background: #e6f3ff;
+  box-shadow:
+          0 0 0 3px rgba(125, 184, 255, 0.1),
+          0 0 14px rgba(125, 184, 255, 0.46);
+  transform: translateX(-50%);
+  animation: nhTransitPulse 1.35s ease-in-out infinite;
+  transition: margin-left var(--nh-motion-duration-medium) var(--nh-motion-ease-standard);
+}
+
+@keyframes nhTransitField {
+  0% {
+    transform: translateX(-24px);
+  }
+
+  100% {
+    transform: translateX(24px);
+  }
+}
+
+@keyframes nhTransitPulse {
+  0%,
+  100% {
+    opacity: 0.75;
+    transform: translateX(-50%) scale(0.88);
+  }
+
+  50% {
+    opacity: 1;
+    transform: translateX(-50%) scale(1.12);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .navigation-transit-stars,
+  .navigation-transit-pulse {
+    animation: none !important;
+  }
 }

--- a/src/components/NavigationPanel.vue
+++ b/src/components/NavigationPanel.vue
@@ -1,7 +1,13 @@
 <script setup>
-import { computed } from 'vue'
-import { donneesSecteurs } from '../game/dataSecteurs'
-import { donneesTrajets } from '../game/dataTrajets'
+import { computed, watch } from "vue";
+import { donneesSecteurs } from "../game/dataSecteurs";
+import { donneesTrajets } from "../game/dataTrajets";
+
+let contexteAudioVoyage = null;
+let tentativeDepartVoyage = false;
+let minuterieTentativeDepartVoyage = null;
+let sonDepartVoyageJoue = false;
+let dernierTickPulseVoyage = null;
 
 const props = defineProps({
   secteurCourantId: {
@@ -14,27 +20,29 @@ const props = defineProps({
   },
   positionLocale: {
     type: String,
-    default: 'station',
+    default: "station",
   },
   modeActif: {
     type: String,
-    default: 'station',
+    default: "station",
   },
-})
+});
 
-const emit = defineEmits(['selectionner-destination', 'voyager'])
+const emit = defineEmits(["selectionner-destination", "voyager"]);
 
 const secteurCourant = computed(() =>
   donneesSecteurs.find((secteur) => secteur.id === props.secteurCourantId),
-)
+);
 
 const secteurDestinationActive = computed(() =>
-  donneesSecteurs.find((secteur) => secteur.id === props.navigation.secteurDestinationId),
-)
+  donneesSecteurs.find(
+    (secteur) => secteur.id === props.navigation.secteurDestinationId,
+  ),
+);
 
 const autresSecteurs = computed(() =>
   donneesSecteurs.filter((secteur) => secteur.id !== props.secteurCourantId),
-)
+);
 
 const trajetSelectionne = computed(() =>
   donneesTrajets.find(
@@ -42,49 +50,406 @@ const trajetSelectionne = computed(() =>
       trajet.origine === props.secteurCourantId &&
       trajet.destination === props.navigation.destinationSelectionneeId,
   ),
-)
+);
 
-const estModeNavigationActif = computed(() => props.modeActif === 'navigation')
+const trajetActif = computed(() =>
+  donneesTrajets.find(
+    (trajet) =>
+      trajet.origine === props.secteurCourantId &&
+      trajet.destination === props.navigation.secteurDestinationId,
+  ),
+);
+
+const estModeNavigationActif = computed(() => props.modeActif === "navigation");
 
 const classesNavigationPanel = computed(() => ({
-  'navigation-panel--active': estModeNavigationActif.value,
-  'navigation-panel--in-transit': props.navigation.enVoyage,
-  'navigation-panel--operations-context':
-    props.positionLocale === 'operations' && !props.navigation.enVoyage,
-  'navigation-panel--station-context':
-    props.positionLocale === 'station' && !props.navigation.enVoyage,
-}))
+  "navigation-panel--active": estModeNavigationActif.value,
+  "navigation-panel--in-transit": props.navigation.enVoyage,
+  "navigation-panel--operations-context":
+    props.positionLocale === "operations" && !props.navigation.enVoyage,
+  "navigation-panel--station-context":
+    props.positionLocale === "station" && !props.navigation.enVoyage,
+}));
 
 const libellePosition = computed(() =>
-  props.positionLocale === 'operations' ? 'Zone d’opérations' : 'Station',
-)
+  props.positionLocale === "operations" ? "Zone d’opérations" : "Station",
+);
 
 const classePastillePosition = computed(() =>
-  props.positionLocale === 'operations'
-    ? 'ui-state-pill ui-state-warning navigation-context-pill'
-    : 'ui-state-pill ui-state-neutral navigation-context-pill',
-)
+  props.positionLocale === "operations"
+    ? "ui-state-pill ui-state-warning navigation-context-pill"
+    : "ui-state-pill ui-state-neutral navigation-context-pill",
+);
 
 const statutNavigation = computed(() => {
   if (props.navigation.enVoyage) {
     return {
-      libelle: 'En transit',
-      classe: 'ui-state-pill ui-state-info navigation-status-pill',
-    }
+      libelle: "En transit",
+      classe: "ui-state-pill ui-state-info navigation-status-pill",
+    };
   }
 
   if (estModeNavigationActif.value) {
     return {
-      libelle: 'Console active',
-      classe: 'ui-state-pill ui-state-success navigation-status-pill',
-    }
+      libelle: "Console active",
+      classe: "ui-state-pill ui-state-success navigation-status-pill",
+    };
   }
 
   return {
-    libelle: 'Prêt au départ',
-    classe: 'ui-state-pill ui-state-neutral navigation-status-pill',
+    libelle: "Prêt au départ",
+    classe: "ui-state-pill ui-state-neutral navigation-status-pill",
+  };
+});
+
+const progressionTransit = computed(() => {
+  const dureeTotale = Number(trajetActif.value?.tempsTrajet || 0);
+  const ticksRestants = Number(props.navigation.ticksRestants || 0);
+
+  if (!props.navigation.enVoyage || dureeTotale <= 0) {
+    return 0;
   }
-})
+
+  const progression = ((dureeTotale - ticksRestants) / dureeTotale) * 100;
+  return Math.min(100, Math.max(0, progression));
+});
+
+const styleProgressionTransit = computed(() => ({
+  "--navigation-transit-progress": `${progressionTransit.value}%`,
+}));
+
+function recupererContexteAudioVoyage() {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  const AudioContextClasse = window.AudioContext || window.webkitAudioContext;
+
+  if (!AudioContextClasse) {
+    return null;
+  }
+
+  if (!contexteAudioVoyage || contexteAudioVoyage.state === "closed") {
+    contexteAudioVoyage = new AudioContextClasse();
+  }
+
+  if (contexteAudioVoyage.state === "suspended") {
+    contexteAudioVoyage.resume();
+  }
+
+  return contexteAudioVoyage;
+}
+
+function jouerSonDepartVoyage() {
+  const contexte = recupererContexteAudioVoyage();
+
+  if (!contexte) {
+    return;
+  }
+
+  const maintenant = contexte.currentTime;
+  const duree = 0.68;
+
+  const gainSortie = contexte.createGain();
+  gainSortie.gain.setValueAtTime(0.52, maintenant);
+  gainSortie.connect(contexte.destination);
+
+  const oscillateurGrave = contexte.createOscillator();
+  oscillateurGrave.type = "sawtooth";
+  oscillateurGrave.frequency.setValueAtTime(168, maintenant);
+  oscillateurGrave.frequency.exponentialRampToValueAtTime(
+    72,
+    maintenant + 0.42,
+  );
+  oscillateurGrave.frequency.exponentialRampToValueAtTime(
+    58,
+    maintenant + duree,
+  );
+
+  const oscillateurHarmonique = contexte.createOscillator();
+  oscillateurHarmonique.type = "sawtooth";
+  oscillateurHarmonique.frequency.setValueAtTime(520, maintenant);
+  oscillateurHarmonique.frequency.exponentialRampToValueAtTime(
+    260,
+    maintenant + 0.3,
+  );
+  oscillateurHarmonique.frequency.exponentialRampToValueAtTime(
+    190,
+    maintenant + duree,
+  );
+
+  const filtre = contexte.createBiquadFilter();
+  filtre.type = "lowpass";
+  filtre.frequency.setValueAtTime(1600, maintenant);
+  filtre.frequency.exponentialRampToValueAtTime(520, maintenant + 0.38);
+  filtre.frequency.exponentialRampToValueAtTime(360, maintenant + duree);
+  filtre.Q.setValueAtTime(1.35, maintenant);
+
+  const gainGrave = contexte.createGain();
+  gainGrave.gain.setValueAtTime(0.0001, maintenant);
+  gainGrave.gain.exponentialRampToValueAtTime(0.08, maintenant + 0.025);
+  gainGrave.gain.linearRampToValueAtTime(0.06, maintenant + 0.24);
+  gainGrave.gain.exponentialRampToValueAtTime(0.0001, maintenant + duree);
+
+  const gainHarmonique = contexte.createGain();
+  gainHarmonique.gain.setValueAtTime(0.0001, maintenant);
+  gainHarmonique.gain.exponentialRampToValueAtTime(0.028, maintenant + 0.018);
+  gainHarmonique.gain.linearRampToValueAtTime(0.018, maintenant + 0.16);
+  gainHarmonique.gain.exponentialRampToValueAtTime(0.0001, maintenant + 0.48);
+
+  oscillateurGrave.connect(gainGrave);
+  oscillateurHarmonique.connect(gainHarmonique);
+  gainGrave.connect(filtre);
+  gainHarmonique.connect(filtre);
+  filtre.connect(gainSortie);
+
+  oscillateurGrave.start(maintenant);
+  oscillateurHarmonique.start(maintenant);
+  oscillateurGrave.stop(maintenant + duree + 0.03);
+  oscillateurHarmonique.stop(maintenant + 0.52);
+}
+
+function jouerSonArriveeVoyage() {
+  const contexte = recupererContexteAudioVoyage();
+
+  if (!contexte) {
+    return;
+  }
+
+  const maintenant = contexte.currentTime;
+  const duree = 0.72;
+
+  const gainSortie = contexte.createGain();
+  gainSortie.gain.setValueAtTime(0.42, maintenant);
+  gainSortie.connect(contexte.destination);
+
+  const oscillateurBulle = contexte.createOscillator();
+  oscillateurBulle.type = "sine";
+  oscillateurBulle.frequency.setValueAtTime(180, maintenant);
+  oscillateurBulle.frequency.exponentialRampToValueAtTime(
+    360,
+    maintenant + 0.12,
+  );
+  oscillateurBulle.frequency.exponentialRampToValueAtTime(
+    210,
+    maintenant + duree,
+  );
+
+  const gainBulle = contexte.createGain();
+  gainBulle.gain.setValueAtTime(0.0001, maintenant);
+  gainBulle.gain.exponentialRampToValueAtTime(0.052, maintenant + 0.025);
+  gainBulle.gain.exponentialRampToValueAtTime(0.024, maintenant + 0.16);
+  gainBulle.gain.exponentialRampToValueAtTime(0.006, maintenant + 0.42);
+  gainBulle.gain.exponentialRampToValueAtTime(0.0001, maintenant + duree);
+
+  const filtreBulle = contexte.createBiquadFilter();
+  filtreBulle.type = "lowpass";
+  filtreBulle.frequency.setValueAtTime(900, maintenant);
+  filtreBulle.frequency.exponentialRampToValueAtTime(420, maintenant + duree);
+  filtreBulle.Q.setValueAtTime(0.9, maintenant);
+
+  const oscillateurReflet = contexte.createOscillator();
+  oscillateurReflet.type = "triangle";
+  oscillateurReflet.frequency.setValueAtTime(620, maintenant + 0.04);
+  oscillateurReflet.frequency.exponentialRampToValueAtTime(
+    380,
+    maintenant + 0.48,
+  );
+
+  const gainReflet = contexte.createGain();
+  gainReflet.gain.setValueAtTime(0.0001, maintenant + 0.04);
+  gainReflet.gain.exponentialRampToValueAtTime(0.015, maintenant + 0.08);
+  gainReflet.gain.exponentialRampToValueAtTime(0.005, maintenant + 0.26);
+  gainReflet.gain.exponentialRampToValueAtTime(0.0001, maintenant + 0.52);
+
+  const filtreReflet = contexte.createBiquadFilter();
+  filtreReflet.type = "bandpass";
+  filtreReflet.frequency.setValueAtTime(520, maintenant + 0.04);
+  filtreReflet.frequency.exponentialRampToValueAtTime(300, maintenant + 0.52);
+  filtreReflet.Q.setValueAtTime(1.4, maintenant + 0.04);
+
+  const bruitBuffer = contexte.createBuffer(
+    1,
+    contexte.sampleRate * duree,
+    contexte.sampleRate,
+  );
+  const donneesBruit = bruitBuffer.getChannelData(0);
+
+  for (let i = 0; i < donneesBruit.length; i += 1) {
+    const progression = i / donneesBruit.length;
+    const enveloppe =
+      Math.sin(Math.PI * progression) * Math.pow(1 - progression, 1.4);
+    donneesBruit[i] = (Math.random() * 2 - 1) * enveloppe;
+  }
+
+  const bruit = contexte.createBufferSource();
+  bruit.buffer = bruitBuffer;
+
+  const filtreBruit = contexte.createBiquadFilter();
+  filtreBruit.type = "lowpass";
+  filtreBruit.frequency.setValueAtTime(1450, maintenant);
+  filtreBruit.frequency.exponentialRampToValueAtTime(380, maintenant + duree);
+  filtreBruit.Q.setValueAtTime(0.65, maintenant);
+
+  const gainBruit = contexte.createGain();
+  gainBruit.gain.setValueAtTime(0.0001, maintenant);
+  gainBruit.gain.exponentialRampToValueAtTime(0.03, maintenant + 0.035);
+  gainBruit.gain.exponentialRampToValueAtTime(0.012, maintenant + 0.18);
+  gainBruit.gain.exponentialRampToValueAtTime(0.002, maintenant + 0.52);
+  gainBruit.gain.exponentialRampToValueAtTime(0.0001, maintenant + duree);
+
+  oscillateurBulle.connect(filtreBulle);
+  filtreBulle.connect(gainBulle);
+  gainBulle.connect(gainSortie);
+
+  oscillateurReflet.connect(filtreReflet);
+  filtreReflet.connect(gainReflet);
+  gainReflet.connect(gainSortie);
+
+  bruit.connect(filtreBruit);
+  filtreBruit.connect(gainBruit);
+  gainBruit.connect(gainSortie);
+
+  oscillateurBulle.start(maintenant);
+  oscillateurReflet.start(maintenant + 0.04);
+  bruit.start(maintenant);
+
+  oscillateurBulle.stop(maintenant + duree + 0.03);
+  oscillateurReflet.stop(maintenant + 0.54);
+  bruit.stop(maintenant + duree);
+}
+
+function jouerPulseTransitVoyage() {
+  const contexte = recupererContexteAudioVoyage();
+
+  if (!contexte) {
+    return;
+  }
+
+  const maintenant = contexte.currentTime;
+  const duree = 0.24;
+
+  const gainSortie = contexte.createGain();
+  gainSortie.gain.setValueAtTime(0.34, maintenant);
+  gainSortie.connect(contexte.destination);
+
+  const oscillateurGrave = contexte.createOscillator();
+  oscillateurGrave.type = "sine";
+  oscillateurGrave.frequency.setValueAtTime(132, maintenant);
+  oscillateurGrave.frequency.exponentialRampToValueAtTime(
+    108,
+    maintenant + duree,
+  );
+
+  const oscillateurTexture = contexte.createOscillator();
+  oscillateurTexture.type = "triangle";
+  oscillateurTexture.frequency.setValueAtTime(260, maintenant);
+  oscillateurTexture.frequency.exponentialRampToValueAtTime(
+    190,
+    maintenant + duree,
+  );
+
+  const filtre = contexte.createBiquadFilter();
+  filtre.type = "lowpass";
+  filtre.frequency.setValueAtTime(720, maintenant);
+  filtre.frequency.exponentialRampToValueAtTime(360, maintenant + duree);
+  filtre.Q.setValueAtTime(0.85, maintenant);
+
+  const gainGrave = contexte.createGain();
+  gainGrave.gain.setValueAtTime(0.0001, maintenant);
+  gainGrave.gain.exponentialRampToValueAtTime(0.072, maintenant + 0.018);
+  gainGrave.gain.linearRampToValueAtTime(0.038, maintenant + 0.09);
+  gainGrave.gain.exponentialRampToValueAtTime(0.0001, maintenant + duree);
+
+  const gainTexture = contexte.createGain();
+  gainTexture.gain.setValueAtTime(0.0001, maintenant);
+  gainTexture.gain.exponentialRampToValueAtTime(0.024, maintenant + 0.024);
+  gainTexture.gain.linearRampToValueAtTime(0.012, maintenant + 0.08);
+  gainTexture.gain.exponentialRampToValueAtTime(0.0001, maintenant + 0.18);
+
+  oscillateurGrave.connect(gainGrave);
+  oscillateurTexture.connect(gainTexture);
+
+  gainGrave.connect(filtre);
+  gainTexture.connect(filtre);
+
+  filtre.connect(gainSortie);
+
+  oscillateurGrave.start(maintenant);
+  oscillateurTexture.start(maintenant);
+
+  oscillateurGrave.stop(maintenant + duree + 0.03);
+  oscillateurTexture.stop(maintenant + 0.2);
+}
+
+function declencherVoyage() {
+  tentativeDepartVoyage = true;
+
+  if (minuterieTentativeDepartVoyage) {
+    clearTimeout(minuterieTentativeDepartVoyage);
+  }
+
+  if (typeof window !== "undefined") {
+    minuterieTentativeDepartVoyage = window.setTimeout(() => {
+      tentativeDepartVoyage = false;
+      minuterieTentativeDepartVoyage = null;
+    }, 500);
+  }
+
+  emit("voyager");
+}
+
+watch(
+  () => props.navigation.enVoyage,
+  (enVoyage, etaitEnVoyage) => {
+    if (
+      enVoyage &&
+      !etaitEnVoyage &&
+      tentativeDepartVoyage &&
+      !sonDepartVoyageJoue
+    ) {
+      jouerSonDepartVoyage();
+      sonDepartVoyageJoue = true;
+      dernierTickPulseVoyage = props.navigation.ticksRestants;
+      tentativeDepartVoyage = false;
+
+      if (minuterieTentativeDepartVoyage) {
+        clearTimeout(minuterieTentativeDepartVoyage);
+        minuterieTentativeDepartVoyage = null;
+      }
+
+      return;
+    }
+
+    if (!enVoyage && etaitEnVoyage && sonDepartVoyageJoue) {
+      jouerSonArriveeVoyage();
+      sonDepartVoyageJoue = false;
+      dernierTickPulseVoyage = null;
+    }
+  },
+);
+
+watch(
+  () => props.navigation.ticksRestants,
+  (ticksRestants, anciensTicksRestants) => {
+    if (!props.navigation.enVoyage || !sonDepartVoyageJoue) {
+      return;
+    }
+
+    if (
+      anciensTicksRestants === undefined ||
+      ticksRestants === anciensTicksRestants ||
+      ticksRestants === dernierTickPulseVoyage
+    ) {
+      return;
+    }
+
+    if (ticksRestants > 0 && ticksRestants < anciensTicksRestants) {
+      jouerPulseTransitVoyage();
+      dernierTickPulseVoyage = ticksRestants;
+    }
+  },
+);
 </script>
 
 <template>
@@ -94,7 +459,9 @@ const statutNavigation = computed(() => {
 
       <div class="navigation-panel-badges">
         <span :class="classePastillePosition">{{ libellePosition }}</span>
-        <span :class="statutNavigation.classe">{{ statutNavigation.libelle }}</span>
+        <span :class="statutNavigation.classe">{{
+          statutNavigation.libelle
+        }}</span>
       </div>
     </div>
 
@@ -102,6 +469,25 @@ const statutNavigation = computed(() => {
       <p>Secteur actuel : {{ secteurCourant?.nom }}</p>
 
       <template v-if="navigation.enVoyage">
+        <div
+          class="navigation-transit-visual"
+          :style="styleProgressionTransit"
+          aria-hidden="true"
+        >
+          <div class="navigation-transit-stars"></div>
+          <div class="navigation-transit-track">
+            <span
+              class="navigation-transit-node navigation-transit-node--origin"
+            ></span>
+            <span class="navigation-transit-line"></span>
+            <span class="navigation-transit-progress"></span>
+            <span class="navigation-transit-pulse"></span>
+            <span
+              class="navigation-transit-node navigation-transit-node--destination"
+            ></span>
+          </div>
+        </div>
+
         <p>Destination : {{ secteurDestinationActive?.nom }}</p>
         <p>Temps restant : {{ navigation.ticksRestants }} ticks</p>
         <p class="navigation-status">Transit inter-sectoriel en cours.</p>
@@ -109,7 +495,10 @@ const statutNavigation = computed(() => {
 
       <template v-else>
         <div class="navigation-destination-row">
-          <label class="navigation-label navigation-label--inline" for="destination-select">
+          <label
+            class="navigation-label navigation-label--inline"
+            for="destination-select"
+          >
             Destination
           </label>
 
@@ -119,7 +508,11 @@ const statutNavigation = computed(() => {
             :value="navigation.destinationSelectionneeId"
             @change="emit('selectionner-destination', $event.target.value)"
           >
-            <option v-for="secteur in autresSecteurs" :key="secteur.id" :value="secteur.id">
+            <option
+              v-for="secteur in autresSecteurs"
+              :key="secteur.id"
+              :value="secteur.id"
+            >
               {{ secteur.nom }}
             </option>
           </select>
@@ -136,7 +529,7 @@ const statutNavigation = computed(() => {
           <button
             class="action-button-with-icon"
             :class="{ 'is-active': estModeNavigationActif }"
-            @click="emit('voyager')"
+            @click="declencherVoyage"
           >
             <span class="button-icon" aria-hidden="true">🧭</span>
             <span>Lancer le trajet</span>


### PR DESCRIPTION
## Objet
Cette MR implémente le ticket #62 en ajoutant une animation légère de voyage et des feedbacks sonores courts pendant les trajets inter-sectoriels.

## Objectif
Renforcer la perception du déplacement pendant les voyages, sans modifier les règles de navigation ni nuire à la lisibilité des informations importantes.

## Modifications réalisées
- ajout d’une animation visible uniquement lorsque `navigation.enVoyage` est actif
- ajout d’une visualisation de transit dans le panneau Navigation
- ajout d’une barre de progression du voyage calculée à partir des ticks restants
- ajout d’un indicateur visuel de déplacement sur la ligne de trajet
- renforcement discret du panneau Navigation pendant le transit
- ajout d’un son court au départ du trajet
- ajout d’un pulse sonore discret à chaque décrément de tick pendant le voyage
- ajout d’un son court d’arrivée, évoquant une sortie de transit / porte stellaire
- protection contre les doublons sonores lorsque plusieurs panneaux Navigation sont affichés
- prise en compte du mode `prefers-reduced-motion` pour les animations visuelles

## Choix d’implémentation
L’animation est liée à l’état réel de navigation :

- elle apparaît uniquement pendant `navigation.enVoyage`
- elle s’arrête automatiquement à la fin du voyage
- elle ne crée aucun délai artificiel
- elle ne modifie ni les durées ni la consommation carburant

Les sons sont générés via le Web Audio API :
- aucun asset audio ajouté
- aucune dépendance externe
- pas de boucle sonore continue
- sons ponctuels uniquement :
  - départ
  - pulse de transit par tick
  - arrivée

## Hors périmètre
Cette MR n’ajoute pas :
- de modification des durées de trajet
- de modification de consommation carburant
- d’incidents de voyage
- de dégâts en transit
- de changement sur le système de navigation
- de rééquilibrage des trajets

Le rééquilibrage des durées et consommations de voyage est prévu dans un ticket séparé.

## Fichiers concernés
- `src/components/NavigationPanel.vue`
- `src/assets/components/navigation.css`

## Tests manuels
- lancer un trajet inter-sectoriel
- vérifier que l’animation apparaît uniquement pendant le voyage
- vérifier que la barre de progression évolue tick par tick
- vérifier que les informations de destination et de temps restant restent lisibles
- vérifier le son court de départ
- vérifier le pulse sonore à chaque décrément de tick
- vérifier le son d’arrivée en fin de trajet
- vérifier l’absence de doublons sonores si le panneau Navigation est affiché à plusieurs endroits
- vérifier que les animations visuelles respectent `prefers-reduced-motion`
- vérifier qu’aucune règle de voyage, durée ou consommation n’est modifiée

## Ticket lié
- #62