### PR TITLE
v0.3.15-129 : fix(ravitaillement): corriger l’affichage du carburant dans les services de station

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -415,7 +415,6 @@ onUnmounted(() => {
         <ShipPanel
           :vaisseau="etat.vaisseau"
           :industrie="etat.industrie"
-          :ressources="etat.ressources"
           :current-tick="temporaliteCourante.ticksGlobaux"
         />
       </section>

--- a/src/components/ShipPanel.vue
+++ b/src/components/ShipPanel.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed } from 'vue'
+import { computed } from "vue";
 
 const props = defineProps({
   vaisseau: {
@@ -10,191 +10,202 @@ const props = defineProps({
     type: Object,
     required: true,
   },
-  ressources: {
-    type: Object,
-    required: true,
-  },
   currentTick: {
     type: Number,
     default: 0,
   },
-})
+});
 
 const roleLabel = computed(() => {
   switch (props.vaisseau.role) {
-    case 'mineur_leger':
-      return 'Mineur léger'
-    case 'mineur_renforce':
-      return 'Mineur renforcé'
-    case 'mineur_lourd':
-      return 'Mineur lourd'
-    case 'transporteur_marchand':
-      return 'Transporteur marchand'
+    case "mineur_leger":
+      return "Mineur léger";
+    case "mineur_renforce":
+      return "Mineur renforcé";
+    case "mineur_lourd":
+      return "Mineur lourd";
+    case "transporteur_marchand":
+      return "Transporteur marchand";
     default:
-      return 'Vaisseau'
+      return "Vaisseau";
   }
-})
+});
 
 const roleClass = computed(() => {
   switch (props.vaisseau.role) {
-    case 'mineur_leger':
-      return 'ship-role-badge--light'
-    case 'mineur_renforce':
-      return 'ship-role-badge--reinforced'
-    case 'mineur_lourd':
-      return 'ship-role-badge--heavy'
-    case 'transporteur_marchand':
-      return 'ship-role-badge--trade'
+    case "mineur_leger":
+      return "ship-role-badge--light";
+    case "mineur_renforce":
+      return "ship-role-badge--reinforced";
+    case "mineur_lourd":
+      return "ship-role-badge--heavy";
+    case "transporteur_marchand":
+      return "ship-role-badge--trade";
     default:
-      return 'ship-role-badge--light'
+      return "ship-role-badge--light";
   }
-})
+});
 
-const descriptionVaisseau = computed(() => props.vaisseau.description || 'Vaisseau opérationnel.')
+const descriptionVaisseau = computed(
+  () => props.vaisseau.description || "Vaisseau opérationnel.",
+);
 
 const assuranceActive = computed(() => {
-  const niveau = props.vaisseau.assuranceNiveau || 'aucune'
-  const expiration = Number(props.vaisseau.assuranceExpirationTick || 0)
+  const niveau = props.vaisseau.assuranceNiveau || "aucune";
+  const expiration = Number(props.vaisseau.assuranceExpirationTick || 0);
 
-  if (niveau === 'aucune') {
-    return false
+  if (niveau === "aucune") {
+    return false;
   }
 
-  return expiration > props.currentTick
-})
+  return expiration > props.currentTick;
+});
 
 const assuranceInfo = computed(() => {
-  const niveau = props.vaisseau.assuranceNiveau || 'aucune'
-  const expiration = Number(props.vaisseau.assuranceExpirationTick || 0)
+  const niveau = props.vaisseau.assuranceNiveau || "aucune";
+  const expiration = Number(props.vaisseau.assuranceExpirationTick || 0);
 
   if (!assuranceActive.value) {
-    if (niveau !== 'aucune' && expiration > 0) {
+    if (niveau !== "aucune" && expiration > 0) {
       return {
-        libelle: 'Contrat expiré',
-        remboursement: '0%',
-        code: 'Exp',
-        classeCss: 'ship-insurance-badge--expired',
-      }
+        libelle: "Contrat expiré",
+        remboursement: "0%",
+        code: "Exp",
+        classeCss: "ship-insurance-badge--expired",
+      };
     }
 
     return {
-      libelle: 'Aucune assurance',
-      remboursement: '0%',
-      code: 'Auc',
-      classeCss: 'ship-insurance-badge--none',
-    }
+      libelle: "Aucune assurance",
+      remboursement: "0%",
+      code: "Auc",
+      classeCss: "ship-insurance-badge--none",
+    };
   }
 
   switch (niveau) {
-    case 'tiers':
+    case "tiers":
       return {
-        libelle: 'Assurance au tiers',
-        remboursement: '33%',
-        code: 'Trs',
-        classeCss: 'ship-insurance-badge--tiers',
-      }
-    case 'standard':
+        libelle: "Assurance au tiers",
+        remboursement: "33%",
+        code: "Trs",
+        classeCss: "ship-insurance-badge--tiers",
+      };
+    case "standard":
       return {
-        libelle: 'Assurance standard',
-        remboursement: '66%',
-        code: 'Std',
-        classeCss: 'ship-insurance-badge--standard',
-      }
-    case 'premium':
+        libelle: "Assurance standard",
+        remboursement: "66%",
+        code: "Std",
+        classeCss: "ship-insurance-badge--standard",
+      };
+    case "premium":
       return {
-        libelle: 'Assurance premium',
-        remboursement: '100%',
-        code: 'Prm',
-        classeCss: 'ship-insurance-badge--premium',
-      }
-    case 'elite':
+        libelle: "Assurance premium",
+        remboursement: "100%",
+        code: "Prm",
+        classeCss: "ship-insurance-badge--premium",
+      };
+    case "elite":
       return {
-        libelle: 'Assurance élite',
-        remboursement: '125%',
-        code: 'Elt',
-        classeCss: 'ship-insurance-badge--elite',
-      }
+        libelle: "Assurance élite",
+        remboursement: "125%",
+        code: "Elt",
+        classeCss: "ship-insurance-badge--elite",
+      };
     default:
       return {
-        libelle: 'Aucune assurance',
-        remboursement: '0%',
-        code: 'Auc',
-        classeCss: 'ship-insurance-badge--none',
-      }
+        libelle: "Aucune assurance",
+        remboursement: "0%",
+        code: "Auc",
+        classeCss: "ship-insurance-badge--none",
+      };
   }
-})
+});
 
 const coquePourcentage = computed(() => {
-  if (!props.vaisseau.coqueMax) return 0
+  if (!props.vaisseau.coqueMax) return 0;
   return Math.max(
     0,
-    Math.min(100, Math.round((props.vaisseau.coque / props.vaisseau.coqueMax) * 100)),
-  )
-})
+    Math.min(
+      100,
+      Math.round((props.vaisseau.coque / props.vaisseau.coqueMax) * 100),
+    ),
+  );
+});
 
 const etatCoque = computed(() => {
-  const pourcentage = coquePourcentage.value
+  const pourcentage = coquePourcentage.value;
 
   if (pourcentage <= 0) {
     return {
-      libelle: 'Hors service',
-      classeCss: 'ship-hull-badge--hors-service',
-    }
+      libelle: "Hors service",
+      classeCss: "ship-hull-badge--hors-service",
+    };
   }
 
   if (pourcentage <= 39) {
     return {
-      libelle: 'Critique',
-      classeCss: 'ship-hull-badge--critique',
-    }
+      libelle: "Critique",
+      classeCss: "ship-hull-badge--critique",
+    };
   }
 
   if (pourcentage <= 74) {
     return {
-      libelle: 'Dégradée',
-      classeCss: 'ship-hull-badge--degradee',
-    }
+      libelle: "Dégradée",
+      classeCss: "ship-hull-badge--degradee",
+    };
   }
 
   return {
-    libelle: 'Nominale',
-    classeCss: 'ship-hull-badge--nominale',
-  }
-})
+    libelle: "Nominale",
+    classeCss: "ship-hull-badge--nominale",
+  };
+});
 
-const carburantActuel = computed(() => Number(props.ressources?.carburant) || 0)
+const carburantActuel = computed(() => Number(props.vaisseau?.carburant) || 0);
 
 const carburantPourcentage = computed(() => {
-  if (!props.vaisseau.carburantMax) return 0
+  if (!props.vaisseau.carburantMax) return 0;
   return Math.max(
     0,
-    Math.min(100, Math.round((carburantActuel.value / props.vaisseau.carburantMax) * 100)),
-  )
-})
+    Math.min(
+      100,
+      Math.round((carburantActuel.value / props.vaisseau.carburantMax) * 100),
+    ),
+  );
+});
 
 const carburantEtatClass = computed(() => {
-  if (carburantPourcentage.value <= 15) return 'ship-fuel-badge--critique'
-  if (carburantPourcentage.value <= 40) return 'ship-fuel-badge--degrade'
-  return 'ship-fuel-badge--nominal'
-})
+  if (carburantPourcentage.value <= 15) return "ship-fuel-badge--critique";
+  if (carburantPourcentage.value <= 40) return "ship-fuel-badge--degrade";
+  return "ship-fuel-badge--nominal";
+});
 
 const carburantEtatLibelle = computed(() => {
-  if (carburantPourcentage.value <= 15) return 'Réserve critique'
-  if (carburantPourcentage.value <= 40) return 'Réserve basse'
-  return 'Réserve correcte'
-})
+  if (carburantPourcentage.value <= 15) return "Réserve critique";
+  if (carburantPourcentage.value <= 40) return "Réserve basse";
+  return "Réserve correcte";
+});
 
 const classesPanneauVaisseau = computed(() => ({
-  'ship-panel--hull-nominale': etatCoque.value.classeCss === 'ship-hull-badge--nominale',
-  'ship-panel--hull-degradee': etatCoque.value.classeCss === 'ship-hull-badge--degradee',
-  'ship-panel--hull-critique': etatCoque.value.classeCss === 'ship-hull-badge--critique',
-  'ship-panel--hull-hors-service': etatCoque.value.classeCss === 'ship-hull-badge--hors-service',
-  'ship-panel--fuel-nominal': carburantEtatClass.value === 'ship-fuel-badge--nominal',
-  'ship-panel--fuel-degrade': carburantEtatClass.value === 'ship-fuel-badge--degrade',
-  'ship-panel--fuel-critique': carburantEtatClass.value === 'ship-fuel-badge--critique',
-}))
+  "ship-panel--hull-nominale":
+    etatCoque.value.classeCss === "ship-hull-badge--nominale",
+  "ship-panel--hull-degradee":
+    etatCoque.value.classeCss === "ship-hull-badge--degradee",
+  "ship-panel--hull-critique":
+    etatCoque.value.classeCss === "ship-hull-badge--critique",
+  "ship-panel--hull-hors-service":
+    etatCoque.value.classeCss === "ship-hull-badge--hors-service",
+  "ship-panel--fuel-nominal":
+    carburantEtatClass.value === "ship-fuel-badge--nominal",
+  "ship-panel--fuel-degrade":
+    carburantEtatClass.value === "ship-fuel-badge--degrade",
+  "ship-panel--fuel-critique":
+    carburantEtatClass.value === "ship-fuel-badge--critique",
+}));
 
-const nombreDronesActifs = computed(() => props.industrie?.drones?.length || 0)
+const nombreDronesActifs = computed(() => props.industrie?.drones?.length || 0);
 </script>
 
 <template>
@@ -283,7 +294,9 @@ const nombreDronesActifs = computed(() => props.industrie?.drones?.length || 0)
       </p>
       <p>
         <span>Drones</span>
-        <strong>{{ nombreDronesActifs }} / {{ vaisseau.dronesMiniersMax }}</strong>
+        <strong
+          >{{ nombreDronesActifs }} / {{ vaisseau.dronesMiniersMax }}</strong
+        >
       </p>
     </div>
   </section>

--- a/src/components/StationServicesPanel.vue
+++ b/src/components/StationServicesPanel.vue
@@ -1,820 +1,942 @@
 <script setup>
-import { computed } from 'vue'
-import { donneesSecteurs } from '../game/dataSecteurs'
-import { donneesVaisseaux } from '../game/dataVaisseaux'
+import { computed } from "vue";
+import { donneesSecteurs } from "../game/dataSecteurs";
+import { donneesVaisseaux } from "../game/dataVaisseaux";
 import {
-    calculerCoursLocauxPourStation,
-    calculerTauxTaxePourSecurite,
-    construireResumeMarcheStation,
-    formaterPourcentageTaxe,
-} from '../game/systemeCommerce'
+  calculerCoursLocauxPourStation,
+  calculerTauxTaxePourSecurite,
+  construireResumeMarcheStation,
+  formaterPourcentageTaxe,
+} from "../game/systemeCommerce";
 import {
-    calculerCoutReparationPartielleVaisseau,
-    calculerCoutReparationVaisseau,
-    calculerPointsCoqueManquants,
-    calculerPointsReparationPartielle,
-    COUT_REPARATION_PAR_POINT,
-} from '../game/systemeReparation'
+  calculerCoutReparationPartielleVaisseau,
+  calculerCoutReparationVaisseau,
+  calculerPointsCoqueManquants,
+  calculerPointsReparationPartielle,
+  COUT_REPARATION_PAR_POINT,
+} from "../game/systemeReparation";
 
 const props = defineProps({
-    secteurCourant: {
-        type: Object,
-        required: true,
-    },
-    vaisseau: {
-        type: Object,
-        required: true,
-    },
-    ressources: {
-        type: Object,
-        required: true,
-    },
-    sousModeStation: {
-        type: String,
-        required: true,
-    },
-    positionLocale: {
-        type: String,
-        required: true,
-    },
-    economie: {
-        type: Object,
-        required: true,
-    },
-    currentTick: {
-        type: Number,
-        default: 0,
-    },
-})
+  secteurCourant: {
+    type: Object,
+    required: true,
+  },
+  vaisseau: {
+    type: Object,
+    required: true,
+  },
+  ressources: {
+    type: Object,
+    required: true,
+  },
+  sousModeStation: {
+    type: String,
+    required: true,
+  },
+  positionLocale: {
+    type: String,
+    required: true,
+  },
+  economie: {
+    type: Object,
+    required: true,
+  },
+  currentTick: {
+    type: Number,
+    default: 0,
+  },
+});
 
 const emit = defineEmits([
-    'changer-sous-mode-station',
-    'vendre',
-    'vendre-bien',
-    'acheter-bien',
-    'ravitailler',
-    'acheter-drone',
-    'reparer-vaisseau',
-    'reparer-partiellement-vaisseau',
-    'souscrire-assurance',
-    'aller-operations',
-    'retour-station',
-])
+  "changer-sous-mode-station",
+  "vendre",
+  "vendre-bien",
+  "acheter-bien",
+  "ravitailler",
+  "acheter-drone",
+  "reparer-vaisseau",
+  "reparer-partiellement-vaisseau",
+  "souscrire-assurance",
+  "aller-operations",
+  "retour-station",
+]);
 
-const TICKS_PAR_JOUR = 24
+const TICKS_PAR_JOUR = 24;
 
 const secteur = computed(() =>
-    donneesSecteurs.find((entree) => entree.id === props.secteurCourant.id),
-)
+  donneesSecteurs.find((entree) => entree.id === props.secteurCourant.id),
+);
 
-const station = computed(() => secteur.value?.stationPrincipale ?? null)
+const station = computed(() => secteur.value?.stationPrincipale ?? null);
 
-const carburantManquant = computed(() => props.vaisseau.carburantMax - props.ressources.carburant)
+const carburantActuel = computed(() => Number(props.vaisseau?.carburant) || 0);
 
-const coutCarburantUnitaire = computed(() => station.value?.economie?.coutCarburantParUnite ?? 1)
+const carburantManquant = computed(() =>
+  Math.max(0, Number(props.vaisseau.carburantMax || 0) - carburantActuel.value),
+);
+
+const coutCarburantUnitaire = computed(
+  () => station.value?.economie?.coutCarburantParUnite ?? 1,
+);
 
 const coutRavitaillementComplet = computed(() => {
-    return Math.max(0, carburantManquant.value) * coutCarburantUnitaire.value
-})
+  return Math.max(0, carburantManquant.value) * coutCarburantUnitaire.value;
+});
 
-const tauxTaxe = computed(() => calculerTauxTaxePourSecurite(secteur.value?.securite ?? 1))
+const tauxTaxe = computed(() =>
+  calculerTauxTaxePourSecurite(secteur.value?.securite ?? 1),
+);
 
-const taxeLocalePourcent = computed(() => formaterPourcentageTaxe(tauxTaxe.value))
+const taxeLocalePourcent = computed(() =>
+  formaterPourcentageTaxe(tauxTaxe.value),
+);
 
 const coursLocaux = computed(() =>
-    calculerCoursLocauxPourStation(station.value, props.ressources.minerais || {}),
-)
+  calculerCoursLocauxPourStation(
+    station.value,
+    props.ressources.minerais || {},
+  ),
+);
 
-const resumeMarche = computed(() => construireResumeMarcheStation(station.value))
+const resumeMarche = computed(() =>
+  construireResumeMarcheStation(station.value),
+);
 
-const souteRestante = computed(() => props.vaisseau.souteMax - props.vaisseau.soute)
+const souteRestante = computed(
+  () => props.vaisseau.souteMax - props.vaisseau.soute,
+);
 
 const profilMarcheLabel = computed(() => {
-    const typeStation = station.value?.type || ''
+  const typeStation = station.value?.type || "";
 
-    if (typeStation.includes('commerciale')) return 'Hub commercial généraliste'
-    if (typeStation.includes('industrielle')) return 'Marché industriel de transit'
-    if (typeStation.includes('chantier')) return 'Débouché métallurgique et logistique'
-    if (typeStation.includes('mouillage')) return 'Marché frontalier brut'
-    if (typeStation.includes('port_franc')) return 'Port spéculatif périphérique'
-    if (typeStation.includes('terminal')) return 'Point d’appui avancé'
-    return 'Marché local'
-})
+  if (typeStation.includes("commerciale")) return "Hub commercial généraliste";
+  if (typeStation.includes("industrielle"))
+    return "Marché industriel de transit";
+  if (typeStation.includes("chantier"))
+    return "Débouché métallurgique et logistique";
+  if (typeStation.includes("mouillage")) return "Marché frontalier brut";
+  if (typeStation.includes("port_franc")) return "Port spéculatif périphérique";
+  if (typeStation.includes("terminal")) return "Point d’appui avancé";
+  return "Marché local";
+});
 
-const coutDroneMinier = computed(() => props.economie?.coutDroneMinier ?? 400)
+const coutDroneMinier = computed(() => props.economie?.coutDroneMinier ?? 400);
 
-const pointsCoqueManquants = computed(() => calculerPointsCoqueManquants(props.vaisseau))
-const pointsReparationPartielle = computed(() => calculerPointsReparationPartielle(props.vaisseau))
+const pointsCoqueManquants = computed(() =>
+  calculerPointsCoqueManquants(props.vaisseau),
+);
+const pointsReparationPartielle = computed(() =>
+  calculerPointsReparationPartielle(props.vaisseau),
+);
 
-const coutReparation = computed(() => calculerCoutReparationVaisseau(props.vaisseau))
+const coutReparation = computed(() =>
+  calculerCoutReparationVaisseau(props.vaisseau),
+);
 const coutReparationPartielle = computed(() =>
-    calculerCoutReparationPartielleVaisseau(props.vaisseau),
-)
+  calculerCoutReparationPartielleVaisseau(props.vaisseau),
+);
 
-const reparationNecessaire = computed(() => pointsCoqueManquants.value > 0)
+const reparationNecessaire = computed(() => pointsCoqueManquants.value > 0);
 
 const reparationAbordable = computed(
-    () => reparationNecessaire.value && (props.ressources?.credits || 0) >= coutReparation.value,
-)
+  () =>
+    reparationNecessaire.value &&
+    (props.ressources?.credits || 0) >= coutReparation.value,
+);
 
 const reparationPartielleAbordable = computed(
-    () =>
-        reparationNecessaire.value &&
-        pointsReparationPartielle.value > 0 &&
-        (props.ressources?.credits || 0) >= coutReparationPartielle.value,
-)
+  () =>
+    reparationNecessaire.value &&
+    pointsReparationPartielle.value > 0 &&
+    (props.ressources?.credits || 0) >= coutReparationPartielle.value,
+);
 
-const tarifAtelier = computed(() => `${COUT_REPARATION_PAR_POINT} cr / pt`)
+const tarifAtelier = computed(() => `${COUT_REPARATION_PAR_POINT} cr / pt`);
 
-const modeleVaisseau = computed(() =>
-    donneesVaisseaux.find((modele) => modele.id === props.vaisseau.modeleId) || null,
-)
+const modeleVaisseau = computed(
+  () =>
+    donneesVaisseaux.find((modele) => modele.id === props.vaisseau.modeleId) ||
+    null,
+);
 
-const valeurMarchandeVaisseau = computed(() => Number(modeleVaisseau.value?.prix || 0))
+const valeurMarchandeVaisseau = computed(() =>
+  Number(modeleVaisseau.value?.prix || 0),
+);
 
-const assuranceNiveauBrut = computed(() => props.vaisseau.assuranceNiveau || 'aucune')
-const assuranceExpirationTick = computed(() => Number(props.vaisseau.assuranceExpirationTick || 0))
-const assuranceSouscriptionTick = computed(() => Number(props.vaisseau.assuranceSouscriptionTick || 0))
+const assuranceNiveauBrut = computed(
+  () => props.vaisseau.assuranceNiveau || "aucune",
+);
+const assuranceExpirationTick = computed(() =>
+  Number(props.vaisseau.assuranceExpirationTick || 0),
+);
+const assuranceSouscriptionTick = computed(() =>
+  Number(props.vaisseau.assuranceSouscriptionTick || 0),
+);
 
 const assuranceActive = computed(() => {
-    if (assuranceNiveauBrut.value === 'aucune') {
-        return false
-    }
+  if (assuranceNiveauBrut.value === "aucune") {
+    return false;
+  }
 
-    return assuranceExpirationTick.value > props.currentTick
-})
+  return assuranceExpirationTick.value > props.currentTick;
+});
 
 const assuranceTicksRestants = computed(() => {
-    if (!assuranceActive.value) {
-        return 0
-    }
+  if (!assuranceActive.value) {
+    return 0;
+  }
 
-    return Math.max(0, assuranceExpirationTick.value - props.currentTick)
-})
+  return Math.max(0, assuranceExpirationTick.value - props.currentTick);
+});
 
 const assuranceTempsRestantLabel = computed(() => {
-    const restants = assuranceTicksRestants.value
-    const jours = Math.floor(restants / TICKS_PAR_JOUR)
-    const heures = restants % TICKS_PAR_JOUR
-    return `${jours} j · ${heures} h`
-})
+  const restants = assuranceTicksRestants.value;
+  const jours = Math.floor(restants / TICKS_PAR_JOUR);
+  const heures = restants % TICKS_PAR_JOUR;
+  return `${jours} j · ${heures} h`;
+});
 
 const assuranceEtatLabel = computed(() => {
-    if (assuranceNiveauBrut.value === 'aucune') {
-        return 'Aucun contrat'
-    }
+  if (assuranceNiveauBrut.value === "aucune") {
+    return "Aucun contrat";
+  }
 
-    if (assuranceActive.value) {
-        return 'Contrat actif'
-    }
+  if (assuranceActive.value) {
+    return "Contrat actif";
+  }
 
-    return 'Contrat expiré'
-})
+  return "Contrat expiré";
+});
 
-function construireOffreAssurance(niveau, code, nom, remboursement, cout, description, badgeClass) {
-    return {
-        id: niveau,
-        code,
-        nom,
-        remboursement,
-        cout,
-        description,
-        badgeClass,
-    }
+function construireOffreAssurance(
+  niveau,
+  code,
+  nom,
+  remboursement,
+  cout,
+  description,
+  badgeClass,
+) {
+  return {
+    id: niveau,
+    code,
+    nom,
+    remboursement,
+    cout,
+    description,
+    badgeClass,
+  };
 }
 
 const offresAssurance = computed(() => {
-    const base = valeurMarchandeVaisseau.value
-    const arrondir = (valeur) => Math.max(0, Math.round(valeur))
+  const base = valeurMarchandeVaisseau.value;
+  const arrondir = (valeur) => Math.max(0, Math.round(valeur));
 
-    return [
-        construireOffreAssurance(
-            'aucune',
-            'Auc',
-            'Aucune couverture',
-            '0%',
-            0,
-            'Aucun contrat actif. Aucun remboursement en cas de perte.',
-            'station-insurance-badge--none',
-        ),
-        construireOffreAssurance(
-            'tiers',
-            'Trs',
-            'Contrat au tiers',
-            '33%',
-            arrondir(base * 0.04),
-            'Couverture minimale, adaptée aux opérations à faible coût.',
-            'station-insurance-badge--tiers',
-        ),
-        construireOffreAssurance(
-            'standard',
-            'Std',
-            'Contrat standard',
-            '66%',
-            arrondir(base * 0.07),
-            'Couverture intermédiaire pour un usage régulier en secteur civil.',
-            'station-insurance-badge--standard',
-        ),
-        construireOffreAssurance(
-            'premium',
-            'Prm',
-            'Contrat premium',
-            '100%',
-            arrondir(base * 0.11),
-            'Couverture intégrale. Les restrictions de réputation seront appliquées plus tard.',
-            'station-insurance-badge--premium',
-        ),
-        construireOffreAssurance(
-            'elite',
-            'Elt',
-            'Contrat élite',
-            '125%',
-            arrondir(base * 0.16),
-            'Couverture renforcée. Les conditions avancées de réputation seront appliquées ultérieurement.',
-            'station-insurance-badge--elite',
-        ),
-    ]
-})
+  return [
+    construireOffreAssurance(
+      "aucune",
+      "Auc",
+      "Aucune couverture",
+      "0%",
+      0,
+      "Aucun contrat actif. Aucun remboursement en cas de perte.",
+      "station-insurance-badge--none",
+    ),
+    construireOffreAssurance(
+      "tiers",
+      "Trs",
+      "Contrat au tiers",
+      "33%",
+      arrondir(base * 0.04),
+      "Couverture minimale, adaptée aux opérations à faible coût.",
+      "station-insurance-badge--tiers",
+    ),
+    construireOffreAssurance(
+      "standard",
+      "Std",
+      "Contrat standard",
+      "66%",
+      arrondir(base * 0.07),
+      "Couverture intermédiaire pour un usage régulier en secteur civil.",
+      "station-insurance-badge--standard",
+    ),
+    construireOffreAssurance(
+      "premium",
+      "Prm",
+      "Contrat premium",
+      "100%",
+      arrondir(base * 0.11),
+      "Couverture intégrale. Les restrictions de réputation seront appliquées plus tard.",
+      "station-insurance-badge--premium",
+    ),
+    construireOffreAssurance(
+      "elite",
+      "Elt",
+      "Contrat élite",
+      "125%",
+      arrondir(base * 0.16),
+      "Couverture renforcée. Les conditions avancées de réputation seront appliquées ultérieurement.",
+      "station-insurance-badge--elite",
+    ),
+  ];
+});
 
 const offreAssuranceCourante = computed(() => {
-    const offre = offresAssurance.value.find((entry) => entry.id === assuranceNiveauBrut.value)
-    return offre || offresAssurance.value[0]
-})
+  const offre = offresAssurance.value.find(
+    (entry) => entry.id === assuranceNiveauBrut.value,
+  );
+  return offre || offresAssurance.value[0];
+});
 
 function recupererQuantiteEnSoute(idMinerai) {
-    return props.ressources?.minerais?.[idMinerai] || 0
+  return props.ressources?.minerais?.[idMinerai] || 0;
 }
 
 function calculerQuantiteMaxAchetable(minerai) {
-    const prixUnitaire = minerai?.prixBrut || 0
+  const prixUnitaire = minerai?.prixBrut || 0;
 
-    if (prixUnitaire <= 0) {
-        return 0
-    }
+  if (prixUnitaire <= 0) {
+    return 0;
+  }
 
-    const quantiteParCredits = Math.floor((props.ressources.credits || 0) / prixUnitaire)
-    return Math.max(0, Math.min(souteRestante.value, quantiteParCredits))
+  const quantiteParCredits = Math.floor(
+    (props.ressources.credits || 0) / prixUnitaire,
+  );
+  return Math.max(0, Math.min(souteRestante.value, quantiteParCredits));
 }
 
 function acheterUnMinerai(idMinerai) {
-    emit('acheter-bien', idMinerai, 1)
+  emit("acheter-bien", idMinerai, 1);
 }
 
 function acheterMineraiMax(minerai) {
-    const quantiteMax = calculerQuantiteMaxAchetable(minerai)
+  const quantiteMax = calculerQuantiteMaxAchetable(minerai);
 
-    if (quantiteMax > 0) {
-        emit('acheter-bien', minerai.id, quantiteMax)
-    }
+  if (quantiteMax > 0) {
+    emit("acheter-bien", minerai.id, quantiteMax);
+  }
 }
 
 function vendreUnMinerai(idMinerai) {
-    emit('vendre-bien', idMinerai, 1)
+  emit("vendre-bien", idMinerai, 1);
 }
 
 function vendreMineraiMax(minerai) {
-    const quantiteMax = recupererQuantiteEnSoute(minerai.id)
+  const quantiteMax = recupererQuantiteEnSoute(minerai.id);
 
-    if (quantiteMax > 0) {
-        emit('vendre-bien', minerai.id, quantiteMax)
-    }
+  if (quantiteMax > 0) {
+    emit("vendre-bien", minerai.id, quantiteMax);
+  }
 }
 
 function labelBoutonAssurance(offre) {
-    if (offre.id === 'aucune' && assuranceNiveauBrut.value === 'aucune') {
-        return 'Aucun contrat'
-    }
+  if (offre.id === "aucune" && assuranceNiveauBrut.value === "aucune") {
+    return "Aucun contrat";
+  }
 
-    if (offre.id === assuranceNiveauBrut.value && assuranceActive.value) {
-        return 'Contrat actif'
-    }
+  if (offre.id === assuranceNiveauBrut.value && assuranceActive.value) {
+    return "Contrat actif";
+  }
 
-    if (offre.id === assuranceNiveauBrut.value && !assuranceActive.value && offre.id !== 'aucune') {
-        return 'Renouveler'
-    }
+  if (
+    offre.id === assuranceNiveauBrut.value &&
+    !assuranceActive.value &&
+    offre.id !== "aucune"
+  ) {
+    return "Renouveler";
+  }
 
-    if (offre.id === 'aucune') {
-        return assuranceNiveauBrut.value === 'aucune' ? 'Aucun contrat' : 'Résilier'
-    }
+  if (offre.id === "aucune") {
+    return assuranceNiveauBrut.value === "aucune"
+      ? "Aucun contrat"
+      : "Résilier";
+  }
 
-    return 'Souscrire'
+  return "Souscrire";
 }
 
 function boutonAssuranceDesactive(offre) {
-    if (offre.id === 'aucune' && assuranceNiveauBrut.value === 'aucune') {
-        return true
-    }
+  if (offre.id === "aucune" && assuranceNiveauBrut.value === "aucune") {
+    return true;
+  }
 
-    if (offre.id === assuranceNiveauBrut.value && assuranceActive.value) {
-        return true
-    }
+  if (offre.id === assuranceNiveauBrut.value && assuranceActive.value) {
+    return true;
+  }
 
-    return (props.ressources.credits || 0) < offre.cout
+  return (props.ressources.credits || 0) < offre.cout;
 }
 </script>
 
 <template>
-    <section class="panel station-services-panel" v-if="station">
-        <div class="station-services-header">
-            <h2>⌘ Services de station</h2>
-            <p class="station-services-subtitle">{{ station.nom }} — {{ station.type }}</p>
+  <section class="panel station-services-panel" v-if="station">
+    <div class="station-services-header">
+      <h2>⌘ Services de station</h2>
+      <p class="station-services-subtitle">
+        {{ station.nom }} — {{ station.type }}
+      </p>
+    </div>
+
+    <div class="station-mode-tabs station-mode-tabs--with-launch">
+      <button
+        v-if="positionLocale === 'station'"
+        class="station-launch-button action-button-with-icon"
+        @click="emit('aller-operations')"
+      >
+        <span class="button-icon" aria-hidden="true">⌘</span>
+        <span>Zone d’opérations</span>
+      </button>
+
+      <button
+        :class="{ 'is-active': sousModeStation === 'hangar' }"
+        class="action-button-with-icon"
+        @click="emit('changer-sous-mode-station', 'hangar')"
+      >
+        <span class="button-icon" aria-hidden="true">⌂</span>
+        <span>Hangar</span>
+      </button>
+
+      <button
+        v-if="station.services.commerce"
+        :class="{ 'is-active': sousModeStation === 'commerce' }"
+        class="action-button-with-icon"
+        @click="emit('changer-sous-mode-station', 'commerce')"
+      >
+        <span class="button-icon" aria-hidden="true">✦</span>
+        <span>Commerce</span>
+      </button>
+
+      <button
+        v-if="station.services.ravitaillement"
+        :class="{ 'is-active': sousModeStation === 'ravitaillement' }"
+        class="action-button-with-icon"
+        @click="emit('changer-sous-mode-station', 'ravitaillement')"
+      >
+        <span class="button-icon" aria-hidden="true">⛽</span>
+        <span>Ravitaillement</span>
+      </button>
+
+      <button
+        :class="{ 'is-active': sousModeStation === 'assurance' }"
+        class="action-button-with-icon"
+        @click="emit('changer-sous-mode-station', 'assurance')"
+      >
+        <span class="button-icon" aria-hidden="true">★</span>
+        <span>Assurance</span>
+      </button>
+
+      <button
+        v-if="station.services.atelier"
+        :class="{ 'is-active': sousModeStation === 'atelier' }"
+        class="action-button-with-icon"
+        @click="emit('changer-sous-mode-station', 'atelier')"
+      >
+        <span class="button-icon" aria-hidden="true">⚙</span>
+        <span>Atelier</span>
+      </button>
+    </div>
+
+    <template v-if="positionLocale !== 'station'">
+      <div class="station-service-card station-service-card-commerce">
+        <div class="station-service-card-header">
+          <h3>Accès indisponible</h3>
+          <span class="station-service-badge">Hors station</span>
         </div>
 
-        <div class="station-mode-tabs station-mode-tabs--with-launch">
-            <button
-                v-if="positionLocale === 'station'"
-                class="station-launch-button action-button-with-icon"
-                @click="emit('aller-operations')"
-            >
-                <span class="button-icon" aria-hidden="true">⌘</span>
-                <span>Zone d’opérations</span>
-            </button>
+        <p class="station-service-description">
+          Les services de station ne sont accessibles qu’une fois revenu et
+          amarré à la station locale.
+        </p>
 
-            <button
-                :class="{ 'is-active': sousModeStation === 'hangar' }"
-                class="action-button-with-icon"
-                @click="emit('changer-sous-mode-station', 'hangar')"
-            >
-                <span class="button-icon" aria-hidden="true">⌂</span>
-                <span>Hangar</span>
-            </button>
+        <div class="action-group">
+          <button
+            class="action-button-with-icon"
+            @click="emit('retour-station')"
+          >
+            <span class="button-icon" aria-hidden="true">⌂</span>
+            <span>Retourner à la station</span>
+          </button>
+        </div>
+      </div>
+    </template>
 
-            <button
-                v-if="station.services.commerce"
-                :class="{ 'is-active': sousModeStation === 'commerce' }"
-                class="action-button-with-icon"
-                @click="emit('changer-sous-mode-station', 'commerce')"
-            >
-                <span class="button-icon" aria-hidden="true">✦</span>
-                <span>Commerce</span>
-            </button>
+    <template v-else>
+      <div
+        v-if="sousModeStation === 'hangar'"
+        class="station-service-mode-hangar-scroll"
+      >
+        <slot name="hangar" />
+      </div>
 
-            <button
-                v-if="station.services.ravitaillement"
-                :class="{ 'is-active': sousModeStation === 'ravitaillement' }"
-                class="action-button-with-icon"
-                @click="emit('changer-sous-mode-station', 'ravitaillement')"
-            >
-                <span class="button-icon" aria-hidden="true">⛽</span>
-                <span>Ravitaillement</span>
-            </button>
-
-            <button
-                :class="{ 'is-active': sousModeStation === 'assurance' }"
-                class="action-button-with-icon"
-                @click="emit('changer-sous-mode-station', 'assurance')"
-            >
-                <span class="button-icon" aria-hidden="true">★</span>
-                <span>Assurance</span>
-            </button>
-
-            <button
-                v-if="station.services.atelier"
-                :class="{ 'is-active': sousModeStation === 'atelier' }"
-                class="action-button-with-icon"
-                @click="emit('changer-sous-mode-station', 'atelier')"
-            >
-                <span class="button-icon" aria-hidden="true">⚙</span>
-                <span>Atelier</span>
-            </button>
+      <div
+        v-else-if="sousModeStation === 'commerce'"
+        class="station-service-card station-service-card-commerce station-service-card--scrollable"
+      >
+        <div class="station-service-card-header">
+          <h3>¤ Commerce local</h3>
+          <span class="station-service-badge">Actif</span>
         </div>
 
-        <template v-if="positionLocale !== 'station'">
-            <div class="station-service-card station-service-card-commerce">
-                <div class="station-service-card-header">
-                    <h3>Accès indisponible</h3>
-                    <span class="station-service-badge">Hors station</span>
-                </div>
+        <div class="station-service-grid">
+          <div class="station-service-metric">
+            <span class="station-service-label">Service commercial</span>
+            <strong>Disponible</strong>
+          </div>
 
-                <p class="station-service-description">
-                    Les services de station ne sont accessibles qu’une fois revenu et amarré à la station locale.
-                </p>
+          <div class="station-service-metric">
+            <span class="station-service-label">Taxe locale</span>
+            <strong>{{ taxeLocalePourcent }}</strong>
+          </div>
 
-                <div class="action-group">
-                    <button class="action-button-with-icon" @click="emit('retour-station')">
-                        <span class="button-icon" aria-hidden="true">⌂</span>
-                        <span>Retourner à la station</span>
-                    </button>
-                </div>
-            </div>
-        </template>
+          <div class="station-service-metric">
+            <span class="station-service-label">Soute</span>
+            <strong>{{ vaisseau.soute }} / {{ vaisseau.souteMax }}</strong>
+          </div>
 
-        <template v-else>
-            <div v-if="sousModeStation === 'hangar'" class="station-service-mode-hangar-scroll">
-                <slot name="hangar" />
-            </div>
+          <div class="station-service-metric">
+            <span class="station-service-label">Capacité restante</span>
+            <strong>{{ souteRestante }}</strong>
+          </div>
 
-            <div
-                v-else-if="sousModeStation === 'commerce'"
-                class="station-service-card station-service-card-commerce station-service-card--scrollable"
+          <div class="station-service-metric station-service-metric--full">
+            <span class="station-service-label">Profil de marché</span>
+            <strong>{{ profilMarcheLabel }}</strong>
+          </div>
+        </div>
+
+        <p class="station-service-description">
+          Les achats et ventes utilisent la même soute embarquée. Les cours
+          ci-dessous représentent les prix locaux bruts par unité. La taxe
+          locale s’applique lors des ventes, sur le montant brut total de la
+          transaction.
+        </p>
+
+        <div class="station-market-insights station-market-insights--compact">
+          <div class="station-market-insight-card">
+            <h4>Meilleures ventes locales</h4>
+            <ul
+              v-if="resumeMarche.haussiers.length > 0"
+              class="station-market-list"
             >
-                <div class="station-service-card-header">
-                    <h3>¤ Commerce local</h3>
-                    <span class="station-service-badge">Actif</span>
-                </div>
+              <li v-for="minerai in resumeMarche.haussiers" :key="minerai.id">
+                <span>{{ minerai.nom }}</span>
+                <strong>{{ minerai.variationPourcentageLabel }}</strong>
+              </li>
+            </ul>
+            <p v-else class="panel-note">Aucune prime locale notable.</p>
+          </div>
 
-                <div class="station-service-grid">
-                    <div class="station-service-metric">
-                        <span class="station-service-label">Service commercial</span>
-                        <strong>Disponible</strong>
-                    </div>
+          <div class="station-market-insight-card">
+            <h4>Moins favorisées</h4>
+            <ul
+              v-if="resumeMarche.baissiers.length > 0"
+              class="station-market-list"
+            >
+              <li v-for="minerai in resumeMarche.baissiers" :key="minerai.id">
+                <span>{{ minerai.nom }}</span>
+                <strong>{{ minerai.variationPourcentageLabel }}</strong>
+              </li>
+            </ul>
+            <p v-else class="panel-note">Aucune décote locale notable.</p>
+          </div>
+        </div>
 
-                    <div class="station-service-metric">
-                        <span class="station-service-label">Taxe locale</span>
-                        <strong>{{ taxeLocalePourcent }}</strong>
-                    </div>
-
-                    <div class="station-service-metric">
-                        <span class="station-service-label">Soute</span>
-                        <strong>{{ vaisseau.soute }} / {{ vaisseau.souteMax }}</strong>
-                    </div>
-
-                    <div class="station-service-metric">
-                        <span class="station-service-label">Capacité restante</span>
-                        <strong>{{ souteRestante }}</strong>
-                    </div>
-
-                    <div class="station-service-metric station-service-metric--full">
-                        <span class="station-service-label">Profil de marché</span>
-                        <strong>{{ profilMarcheLabel }}</strong>
-                    </div>
-                </div>
-
-                <p class="station-service-description">
-                    Les achats et ventes utilisent la même soute embarquée. Les cours ci-dessous représentent
-                    les prix locaux bruts par unité. La taxe locale s’applique lors des ventes, sur le montant
-                    brut total de la transaction.
-                </p>
-
-                <div class="station-market-insights station-market-insights--compact">
-                    <div class="station-market-insight-card">
-                        <h4>Meilleures ventes locales</h4>
-                        <ul v-if="resumeMarche.haussiers.length > 0" class="station-market-list">
-                            <li v-for="minerai in resumeMarche.haussiers" :key="minerai.id">
-                                <span>{{ minerai.nom }}</span>
-                                <strong>{{ minerai.variationPourcentageLabel }}</strong>
-                            </li>
-                        </ul>
-                        <p v-else class="panel-note">Aucune prime locale notable.</p>
-                    </div>
-
-                    <div class="station-market-insight-card">
-                        <h4>Moins favorisées</h4>
-                        <ul v-if="resumeMarche.baissiers.length > 0" class="station-market-list">
-                            <li v-for="minerai in resumeMarche.baissiers" :key="minerai.id">
-                                <span>{{ minerai.nom }}</span>
-                                <strong>{{ minerai.variationPourcentageLabel }}</strong>
-                            </li>
-                        </ul>
-                        <p v-else class="panel-note">Aucune décote locale notable.</p>
-                    </div>
-                </div>
-
-                <div class="market-rate-grid market-rate-grid-three-cols">
-                    <div v-for="minerai in coursLocaux" :key="minerai.id" class="market-rate-item">
-                        <div class="market-rate-row market-rate-row--top">
+        <div class="market-rate-grid market-rate-grid-three-cols">
+          <div
+            v-for="minerai in coursLocaux"
+            :key="minerai.id"
+            class="market-rate-item"
+          >
+            <div class="market-rate-row market-rate-row--top">
               <span class="market-rate-name">
                 <span class="resource-icon">{{ minerai.icone }}</span>
                 {{ minerai.abreviation }}
               </span>
 
-                            <span class="market-rate-values">{{ minerai.prixBrut }} cr</span>
-                        </div>
+              <span class="market-rate-values">{{ minerai.prixBrut }} cr</span>
+            </div>
 
-                        <div class="market-rate-row market-rate-row--bottom">
+            <div class="market-rate-row market-rate-row--bottom">
               <span
-                  class="market-rate-variation"
-                  :class="{
+                class="market-rate-variation"
+                :class="{
                   'market-rate-variation-up': minerai.variation === 'hausse',
                   'market-rate-variation-down': minerai.variation === 'baisse',
-                  'market-rate-variation-stable': minerai.variation === 'stable',
+                  'market-rate-variation-stable':
+                    minerai.variation === 'stable',
                 }"
               >
-                {{ minerai.variationSymbole }} {{ minerai.variationPourcentageLabel }}
+                {{ minerai.variationSymbole }}
+                {{ minerai.variationPourcentageLabel }}
               </span>
 
-                            <span class="market-rate-average">moy. {{ minerai.prixMoyen }} cr</span>
-                        </div>
-
-                        <div class="market-rate-row market-rate-row--bottom">
-                            <span class="market-rate-average">En soute : {{ recupererQuantiteEnSoute(minerai.id) }}</span>
-                        </div>
-
-                        <div class="action-group-market">
-                            <button
-                                class="market-rate-buy-button"
-                                :disabled="souteRestante <= 0 || ressources.credits < minerai.prixBrut"
-                                @click="acheterUnMinerai(minerai.id)"
-                            >
-                                +1
-                            </button>
-
-                            <button
-                                class="market-rate-buy-button"
-                                :disabled="calculerQuantiteMaxAchetable(minerai) <= 0"
-                                @click="acheterMineraiMax(minerai)"
-                            >
-                                +Max
-                            </button>
-
-                            <button
-                                class="market-rate-buy-button"
-                                :disabled="recupererQuantiteEnSoute(minerai.id) <= 0"
-                                @click="vendreUnMinerai(minerai.id)"
-                            >
-                                -1
-                            </button>
-
-                            <button
-                                class="market-rate-buy-button"
-                                :disabled="recupererQuantiteEnSoute(minerai.id) <= 0"
-                                @click="vendreMineraiMax(minerai)"
-                            >
-                                -Max
-                            </button>
-                        </div>
-                    </div>
-                </div>
-
-                <p class="market-rate-legend">
-                    Affichage : cours local brut par unité, comparé au cours moyen galactique.
-                </p>
-
-                <div class="action-group">
-                    <button class="action-button-with-icon" @click="emit('vendre')">
-                        <span class="button-icon" aria-hidden="true">✦</span>
-                        <span>Vendre le contenu minéral de la soute</span>
-                    </button>
-                </div>
+              <span class="market-rate-average"
+                >moy. {{ minerai.prixMoyen }} cr</span
+              >
             </div>
 
-            <div
-                v-else-if="sousModeStation === 'ravitaillement'"
-                class="station-service-card station-service-card-fuel"
-            >
-                <div class="station-service-card-header">
-                    <h3>⛽ Ravitaillement</h3>
-                    <span class="station-service-badge">Actif</span>
-                </div>
-
-                <div class="station-service-grid">
-                    <div class="station-service-metric">
-                        <span class="station-service-label">Carburant actuel</span>
-                        <strong>{{ ressources.carburant }} / {{ vaisseau.carburantMax }}</strong>
-                    </div>
-
-                    <div class="station-service-metric">
-                        <span class="station-service-label">Carburant manquant</span>
-                        <strong>{{ carburantManquant }}</strong>
-                    </div>
-
-                    <div class="station-service-metric">
-                        <span class="station-service-label">Prix unitaire</span>
-                        <strong>{{ coutCarburantUnitaire }} cr. / unité</strong>
-                    </div>
-
-                    <div class="station-service-metric">
-                        <span class="station-service-label">Coût du plein</span>
-                        <strong>{{ coutRavitaillementComplet }} cr.</strong>
-                    </div>
-                </div>
-
-                <p class="station-service-description">
-                    Recharge du réservoir principal au tarif local de la station.
-                </p>
-
-                <div class="action-group">
-                    <button class="action-button-with-icon" @click="emit('ravitailler')">
-                        <span class="button-icon" aria-hidden="true">⛽</span>
-                        <span>Ravitailler le vaisseau</span>
-                    </button>
-                </div>
+            <div class="market-rate-row market-rate-row--bottom">
+              <span class="market-rate-average"
+                >En soute : {{ recupererQuantiteEnSoute(minerai.id) }}</span
+              >
             </div>
 
-            <div
-                v-else-if="sousModeStation === 'assurance'"
-                class="station-service-card station-service-card-insurance station-service-card--scrollable"
+            <div class="action-group-market">
+              <button
+                class="market-rate-buy-button"
+                :disabled="
+                  souteRestante <= 0 || ressources.credits < minerai.prixBrut
+                "
+                @click="acheterUnMinerai(minerai.id)"
+              >
+                +1
+              </button>
+
+              <button
+                class="market-rate-buy-button"
+                :disabled="calculerQuantiteMaxAchetable(minerai) <= 0"
+                @click="acheterMineraiMax(minerai)"
+              >
+                +Max
+              </button>
+
+              <button
+                class="market-rate-buy-button"
+                :disabled="recupererQuantiteEnSoute(minerai.id) <= 0"
+                @click="vendreUnMinerai(minerai.id)"
+              >
+                -1
+              </button>
+
+              <button
+                class="market-rate-buy-button"
+                :disabled="recupererQuantiteEnSoute(minerai.id) <= 0"
+                @click="vendreMineraiMax(minerai)"
+              >
+                -Max
+              </button>
+            </div>
+          </div>
+        </div>
+
+        <p class="market-rate-legend">
+          Affichage : cours local brut par unité, comparé au cours moyen
+          galactique.
+        </p>
+
+        <div class="action-group">
+          <button class="action-button-with-icon" @click="emit('vendre')">
+            <span class="button-icon" aria-hidden="true">✦</span>
+            <span>Vendre le contenu minéral de la soute</span>
+          </button>
+        </div>
+      </div>
+
+      <div
+        v-else-if="sousModeStation === 'ravitaillement'"
+        class="station-service-card station-service-card-fuel"
+      >
+        <div class="station-service-card-header">
+          <h3>⛽ Ravitaillement</h3>
+          <span class="station-service-badge">Actif</span>
+        </div>
+
+        <div class="station-service-grid">
+          <div class="station-service-metric">
+            <span class="station-service-label">Carburant actuel</span>
+            <strong>{{ carburantActuel }} / {{ vaisseau.carburantMax }}</strong>
+          </div>
+
+          <div class="station-service-metric">
+            <span class="station-service-label">Carburant manquant</span>
+            <strong>{{ carburantManquant }}</strong>
+          </div>
+
+          <div class="station-service-metric">
+            <span class="station-service-label">Prix unitaire</span>
+            <strong>{{ coutCarburantUnitaire }} cr. / unité</strong>
+          </div>
+
+          <div class="station-service-metric">
+            <span class="station-service-label">Coût du plein</span>
+            <strong>{{ coutRavitaillementComplet }} cr.</strong>
+          </div>
+        </div>
+
+        <p class="station-service-description">
+          Recharge du réservoir principal au tarif local de la station.
+        </p>
+
+        <div class="action-group">
+          <button class="action-button-with-icon" @click="emit('ravitailler')">
+            <span class="button-icon" aria-hidden="true">⛽</span>
+            <span>Ravitailler le vaisseau</span>
+          </button>
+        </div>
+      </div>
+
+      <div
+        v-else-if="sousModeStation === 'assurance'"
+        class="station-service-card station-service-card-insurance station-service-card--scrollable"
+      >
+        <div class="station-service-card-header">
+          <h3>★ Service d’assurance</h3>
+          <span class="station-service-badge">Actif</span>
+        </div>
+
+        <div class="station-service-grid">
+          <div class="station-service-metric">
+            <span class="station-service-label">Contrat actuel</span>
+            <strong>{{ assuranceEtatLabel }}</strong>
+          </div>
+
+          <div class="station-service-metric">
+            <span class="station-service-label">Formule</span>
+            <strong>{{ offreAssuranceCourante.nom }}</strong>
+          </div>
+
+          <div class="station-service-metric">
+            <span class="station-service-label">Remboursement</span>
+            <strong>{{
+              assuranceActive ? offreAssuranceCourante.remboursement : "0%"
+            }}</strong>
+          </div>
+
+          <div class="station-service-metric">
+            <span class="station-service-label">Durée standard</span>
+            <strong>30 j · 0 h</strong>
+          </div>
+
+          <div class="station-service-metric">
+            <span class="station-service-label">Vaisseau couvert</span>
+            <strong>{{ vaisseau.nom }}</strong>
+          </div>
+
+          <div class="station-service-metric">
+            <span class="station-service-label">Valeur marchande</span>
+            <strong>{{ valeurMarchandeVaisseau }} cr</strong>
+          </div>
+
+          <div class="station-service-metric">
+            <span class="station-service-label">Souscription</span>
+            <strong v-if="assuranceSouscriptionTick > 0"
+              >T{{ assuranceSouscriptionTick }}</strong
             >
-                <div class="station-service-card-header">
-                    <h3>★ Service d’assurance</h3>
-                    <span class="station-service-badge">Actif</span>
-                </div>
+            <strong v-else>—</strong>
+          </div>
 
-                <div class="station-service-grid">
-                    <div class="station-service-metric">
-                        <span class="station-service-label">Contrat actuel</span>
-                        <strong>{{ assuranceEtatLabel }}</strong>
-                    </div>
+          <div class="station-service-metric">
+            <span class="station-service-label">Échéance</span>
+            <strong v-if="assuranceExpirationTick > 0"
+              >T{{ assuranceExpirationTick }}</strong
+            >
+            <strong v-else>—</strong>
+          </div>
 
-                    <div class="station-service-metric">
-                        <span class="station-service-label">Formule</span>
-                        <strong>{{ offreAssuranceCourante.nom }}</strong>
-                    </div>
+          <div class="station-service-metric station-service-metric--full">
+            <span class="station-service-label">Temps restant</span>
+            <strong>{{
+              assuranceActive ? assuranceTempsRestantLabel : "Contrat inactif"
+            }}</strong>
+          </div>
+        </div>
 
-                    <div class="station-service-metric">
-                        <span class="station-service-label">Remboursement</span>
-                        <strong>{{ assuranceActive ? offreAssuranceCourante.remboursement : '0%' }}</strong>
-                    </div>
+        <p class="station-service-description">
+          Souscription ou renouvellement manuel du contrat d’assurance du
+          vaisseau actif. Un contrat reste valable pendant 720 ticks, soit 30
+          jours standards de jeu.
+        </p>
 
-                    <div class="station-service-metric">
-                        <span class="station-service-label">Durée standard</span>
-                        <strong>30 j · 0 h</strong>
-                    </div>
-
-                    <div class="station-service-metric">
-                        <span class="station-service-label">Vaisseau couvert</span>
-                        <strong>{{ vaisseau.nom }}</strong>
-                    </div>
-
-                    <div class="station-service-metric">
-                        <span class="station-service-label">Valeur marchande</span>
-                        <strong>{{ valeurMarchandeVaisseau }} cr</strong>
-                    </div>
-
-                    <div class="station-service-metric">
-                        <span class="station-service-label">Souscription</span>
-                        <strong v-if="assuranceSouscriptionTick > 0">T{{ assuranceSouscriptionTick }}</strong>
-                        <strong v-else>—</strong>
-                    </div>
-
-                    <div class="station-service-metric">
-                        <span class="station-service-label">Échéance</span>
-                        <strong v-if="assuranceExpirationTick > 0">T{{ assuranceExpirationTick }}</strong>
-                        <strong v-else>—</strong>
-                    </div>
-
-                    <div class="station-service-metric station-service-metric--full">
-                        <span class="station-service-label">Temps restant</span>
-                        <strong>{{ assuranceActive ? assuranceTempsRestantLabel : 'Contrat inactif' }}</strong>
-                    </div>
-                </div>
-
-                <p class="station-service-description">
-                    Souscription ou renouvellement manuel du contrat d’assurance du vaisseau actif. Un contrat reste valable
-                    pendant 720 ticks, soit 30 jours standards de jeu.
-                </p>
-
-                <div class="station-insurance-grid">
-                    <article
-                        v-for="offre in offresAssurance"
-                        :key="offre.id"
-                        class="station-insurance-card"
-                        :class="{
-              'station-insurance-card--active': offre.id === assuranceNiveauBrut && assuranceActive,
-              'station-insurance-card--expired': offre.id === assuranceNiveauBrut && !assuranceActive && offre.id !== 'aucune',
+        <div class="station-insurance-grid">
+          <article
+            v-for="offre in offresAssurance"
+            :key="offre.id"
+            class="station-insurance-card"
+            :class="{
+              'station-insurance-card--active':
+                offre.id === assuranceNiveauBrut && assuranceActive,
+              'station-insurance-card--expired':
+                offre.id === assuranceNiveauBrut &&
+                !assuranceActive &&
+                offre.id !== 'aucune',
             }"
-                    >
-                        <div class="station-insurance-card-head">
+          >
+            <div class="station-insurance-card-head">
               <span class="station-insurance-badge" :class="offre.badgeClass">
                 <span aria-hidden="true">★</span>
                 <span>{{ offre.code }}</span>
               </span>
 
-                            <span v-if="offre.id === assuranceNiveauBrut && assuranceActive" class="station-insurance-current">
+              <span
+                v-if="offre.id === assuranceNiveauBrut && assuranceActive"
+                class="station-insurance-current"
+              >
                 En cours
               </span>
 
-                            <span
-                                v-else-if="offre.id === assuranceNiveauBrut && !assuranceActive && offre.id !== 'aucune'"
-                                class="station-insurance-current station-insurance-current--expired"
-                            >
+              <span
+                v-else-if="
+                  offre.id === assuranceNiveauBrut &&
+                  !assuranceActive &&
+                  offre.id !== 'aucune'
+                "
+                class="station-insurance-current station-insurance-current--expired"
+              >
                 Expiré
               </span>
-                        </div>
-
-                        <h4>{{ offre.nom }}</h4>
-
-                        <div class="station-service-grid station-service-grid--insurance">
-                            <div class="station-service-metric station-service-metric--compact">
-                                <span class="station-service-label">Remboursement</span>
-                                <strong>{{ offre.id === 'aucune' ? '0%' : offre.remboursement }}</strong>
-                            </div>
-
-                            <div class="station-service-metric station-service-metric--compact">
-                                <span class="station-service-label">Coût</span>
-                                <strong>{{ offre.cout }} cr</strong>
-                            </div>
-                        </div>
-
-                        <p class="station-service-description station-service-description--compact">
-                            {{ offre.description }}
-                        </p>
-
-                        <button
-                            class="action-button-with-icon"
-                            :disabled="boutonAssuranceDesactive(offre)"
-                            @click="emit('souscrire-assurance', offre.id)"
-                        >
-                            <span class="button-icon" aria-hidden="true">★</span>
-                            <span>{{ labelBoutonAssurance(offre) }}</span>
-                        </button>
-                    </article>
-                </div>
-
-                <p class="panel-note">
-                    Les niveaux premium et élite restent soumis plus tard à des conditions de réputation. Le renouvellement est
-                    manuel pour cette version.
-                </p>
             </div>
 
-            <div
-                v-else-if="sousModeStation === 'atelier'"
-                class="station-service-card station-service-card-workshop station-service-card--scrollable"
+            <h4>{{ offre.nom }}</h4>
+
+            <div class="station-service-grid station-service-grid--insurance">
+              <div
+                class="station-service-metric station-service-metric--compact"
+              >
+                <span class="station-service-label">Remboursement</span>
+                <strong>{{
+                  offre.id === "aucune" ? "0%" : offre.remboursement
+                }}</strong>
+              </div>
+
+              <div
+                class="station-service-metric station-service-metric--compact"
+              >
+                <span class="station-service-label">Coût</span>
+                <strong>{{ offre.cout }} cr</strong>
+              </div>
+            </div>
+
+            <p
+              class="station-service-description station-service-description--compact"
             >
-                <div class="station-service-card-header">
-                    <h3>⚙ Atelier technique</h3>
-                    <span class="station-service-badge">Actif</span>
-                </div>
+              {{ offre.description }}
+            </p>
 
-                <div
-                    class="station-service-grid station-service-grid--atelier-devis station-service-grid--atelier-devis-5"
-                >
-                    <div class="station-service-metric station-service-metric--compact">
-                        <span class="station-service-label">Coque</span>
-                        <strong>{{ vaisseau.coque }} / {{ vaisseau.coqueMax }}</strong>
-                    </div>
+            <button
+              class="action-button-with-icon"
+              :disabled="boutonAssuranceDesactive(offre)"
+              @click="emit('souscrire-assurance', offre.id)"
+            >
+              <span class="button-icon" aria-hidden="true">★</span>
+              <span>{{ labelBoutonAssurance(offre) }}</span>
+            </button>
+          </article>
+        </div>
 
-                    <div class="station-service-metric station-service-metric--compact">
-                        <span class="station-service-label">À réparer</span>
-                        <strong>{{ pointsCoqueManquants }} pts</strong>
-                    </div>
+        <p class="panel-note">
+          Les niveaux premium et élite restent soumis plus tard à des conditions
+          de réputation. Le renouvellement est manuel pour cette version.
+        </p>
+      </div>
 
-                    <div class="station-service-metric station-service-metric--compact">
-                        <span class="station-service-label">Tarif atelier</span>
-                        <strong>{{ tarifAtelier }}</strong>
-                    </div>
+      <div
+        v-else-if="sousModeStation === 'atelier'"
+        class="station-service-card station-service-card-workshop station-service-card--scrollable"
+      >
+        <div class="station-service-card-header">
+          <h3>⚙ Atelier technique</h3>
+          <span class="station-service-badge">Actif</span>
+        </div>
 
-                    <div class="station-service-metric station-service-metric--compact">
-                        <span class="station-service-label">Coût partiel</span>
-                        <strong v-if="reparationNecessaire">{{ coutReparationPartielle }} cr</strong>
-                        <strong v-else>—</strong>
-                    </div>
+        <div
+          class="station-service-grid station-service-grid--atelier-devis station-service-grid--atelier-devis-5"
+        >
+          <div class="station-service-metric station-service-metric--compact">
+            <span class="station-service-label">Coque</span>
+            <strong>{{ vaisseau.coque }} / {{ vaisseau.coqueMax }}</strong>
+          </div>
 
-                    <div class="station-service-metric station-service-metric--compact">
-                        <span class="station-service-label">Coût complet</span>
-                        <strong v-if="reparationNecessaire">{{ coutReparation }} cr</strong>
-                        <strong v-else>—</strong>
-                    </div>
-                </div>
+          <div class="station-service-metric station-service-metric--compact">
+            <span class="station-service-label">À réparer</span>
+            <strong>{{ pointsCoqueManquants }} pts</strong>
+          </div>
 
-                <p class="station-service-description station-service-description--compact">
-                    Réparation, amélioration et support technique du vaisseau actif.
-                </p>
+          <div class="station-service-metric station-service-metric--compact">
+            <span class="station-service-label">Tarif atelier</span>
+            <strong>{{ tarifAtelier }}</strong>
+          </div>
 
-                <div class="action-group action-group--atelier-main action-group--atelier-main-split">
-                    <button
-                        class="action-button-with-icon"
-                        :disabled="!reparationNecessaire || !reparationPartielleAbordable"
-                        @click="emit('reparer-partiellement-vaisseau')"
-                    >
-                        <span class="button-icon" aria-hidden="true">🛠</span>
-                        <span>Réparation partielle (+{{ pointsReparationPartielle }})</span>
-                    </button>
+          <div class="station-service-metric station-service-metric--compact">
+            <span class="station-service-label">Coût partiel</span>
+            <strong v-if="reparationNecessaire"
+              >{{ coutReparationPartielle }} cr</strong
+            >
+            <strong v-else>—</strong>
+          </div>
 
-                    <button
-                        class="action-button-with-icon"
-                        :disabled="!reparationNecessaire || !reparationAbordable"
-                        @click="emit('reparer-vaisseau')"
-                    >
-                        <span class="button-icon" aria-hidden="true">🛠</span>
-                        <span>Réparation complète</span>
-                    </button>
-                </div>
+          <div class="station-service-metric station-service-metric--compact">
+            <span class="station-service-label">Coût complet</span>
+            <strong v-if="reparationNecessaire">{{ coutReparation }} cr</strong>
+            <strong v-else>—</strong>
+          </div>
+        </div>
 
-                <p v-if="!reparationNecessaire" class="panel-note">
-                    Coque intacte.
-                </p>
+        <p
+          class="station-service-description station-service-description--compact"
+        >
+          Réparation, amélioration et support technique du vaisseau actif.
+        </p>
 
-                <p
-                    v-else-if="!reparationPartielleAbordable && !reparationAbordable"
-                    class="panel-note panel-note-warning"
-                >
-                    Crédits insuffisants pour toute réparation.
-                </p>
+        <div
+          class="action-group action-group--atelier-main action-group--atelier-main-split"
+        >
+          <button
+            class="action-button-with-icon"
+            :disabled="!reparationNecessaire || !reparationPartielleAbordable"
+            @click="emit('reparer-partiellement-vaisseau')"
+          >
+            <span class="button-icon" aria-hidden="true">🛠</span>
+            <span>Réparation partielle (+{{ pointsReparationPartielle }})</span>
+          </button>
 
-                <p
-                    v-else-if="reparationPartielleAbordable && !reparationAbordable"
-                    class="panel-note panel-note-warning"
-                >
-                    Réparation partielle possible. Crédits insuffisants pour une réparation complète.
-                </p>
+          <button
+            class="action-button-with-icon"
+            :disabled="!reparationNecessaire || !reparationAbordable"
+            @click="emit('reparer-vaisseau')"
+          >
+            <span class="button-icon" aria-hidden="true">🛠</span>
+            <span>Réparation complète</span>
+          </button>
+        </div>
 
-                <div class="action-group action-group--atelier-support">
-                    <div class="station-service-metric station-service-metric--compact station-service-metric--support">
-                        <span class="station-service-label">Drone minier</span>
-                        <strong>{{ coutDroneMinier }} cr / unité</strong>
-                    </div>
+        <p v-if="!reparationNecessaire" class="panel-note">Coque intacte.</p>
 
-                    <button class="action-button-with-icon" @click="emit('acheter-drone')">
-                        <span class="button-icon" aria-hidden="true">⛏</span>
-                        <span>Acheter un drone</span>
-                    </button>
-                </div>
+        <p
+          v-else-if="!reparationPartielleAbordable && !reparationAbordable"
+          class="panel-note panel-note-warning"
+        >
+          Crédits insuffisants pour toute réparation.
+        </p>
 
-                <div class="station-atelier-slot">
-                    <slot name="atelier" />
-                </div>
-            </div>
-        </template>
-    </section>
+        <p
+          v-else-if="reparationPartielleAbordable && !reparationAbordable"
+          class="panel-note panel-note-warning"
+        >
+          Réparation partielle possible. Crédits insuffisants pour une
+          réparation complète.
+        </p>
+
+        <div class="action-group action-group--atelier-support">
+          <div
+            class="station-service-metric station-service-metric--compact station-service-metric--support"
+          >
+            <span class="station-service-label">Drone minier</span>
+            <strong>{{ coutDroneMinier }} cr / unité</strong>
+          </div>
+
+          <button
+            class="action-button-with-icon"
+            @click="emit('acheter-drone')"
+          >
+            <span class="button-icon" aria-hidden="true">⛏</span>
+            <span>Acheter un drone</span>
+          </button>
+        </div>
+
+        <div class="station-atelier-slot">
+          <slot name="atelier" />
+        </div>
+      </div>
+    </template>
+  </section>
 </template>

--- a/src/game/donneesInitiales.js
+++ b/src/game/donneesInitiales.js
@@ -1,8 +1,8 @@
-import { donneesVaisseaux } from './dataVaisseaux'
-import { donneesMinerais } from './dataMinerais'
+import { donneesVaisseaux } from "./dataVaisseaux";
+import { donneesMinerais } from "./dataMinerais";
 
 function creerStockMineraisInitial() {
-  return Object.fromEntries(donneesMinerais.map((minerai) => [minerai.id, 0]))
+  return Object.fromEntries(donneesMinerais.map((minerai) => [minerai.id, 0]));
 }
 
 function creerInstanceVaisseauDepuisModele(modele) {
@@ -20,34 +20,35 @@ function creerInstanceVaisseauDepuisModele(modele) {
     dronesMiniersMax: modele.dronesMiniersMax,
     carburant: modele.carburantMax,
     carburantMax: modele.carburantMax,
-    assuranceNiveau: 'aucune',
+    assuranceNiveau: "aucune",
     assuranceSouscriptionTick: 0,
     assuranceExpirationTick: 0,
     scanner: structuredClone(modele.scanner || {}),
     ameliorations: structuredClone(modele.ameliorations || []),
     ameliorationsMax: structuredClone(modele.ameliorationsMax || {}),
-  }
+  };
 }
 
 export function creerEtatInitialJeu() {
-  const modeleDepart = donneesVaisseaux.find((vaisseau) => vaisseau.id === 'hw_mule')
-  const vaisseauDepart = creerInstanceVaisseauDepuisModele(modeleDepart)
+  const modeleDepart = donneesVaisseaux.find(
+    (vaisseau) => vaisseau.id === "hw_mule",
+  );
+  const vaisseauDepart = creerInstanceVaisseauDepuisModele(modeleDepart);
 
   return {
     meta: {
-      version: '0.3.15',
-      auteur: 'Kaemyll',
+      version: "0.3.15",
+      auteur: "Kaemyll",
       annee: 2026,
     },
 
     joueur: {
-      identite: 'Sans indicatif',
-      reputation: 'I — Neutre',
+      identite: "Sans indicatif",
+      reputation: "I — Neutre",
     },
 
     ressources: {
       credits: 0,
-      carburant: vaisseauDepart.carburant,
       minerais: creerStockMineraisInitial(),
       cargaisonMarchande: {},
     },
@@ -67,6 +68,7 @@ export function creerEtatInitialJeu() {
       souteMax: vaisseauDepart.souteMax,
       puissanceMiniere: vaisseauDepart.puissanceMiniere,
       dronesMiniersMax: vaisseauDepart.dronesMiniersMax,
+      carburant: vaisseauDepart.carburant,
       carburantMax: vaisseauDepart.carburantMax,
       assuranceNiveau: vaisseauDepart.assuranceNiveau,
       assuranceSouscriptionTick: vaisseauDepart.assuranceSouscriptionTick,
@@ -82,14 +84,14 @@ export function creerEtatInitialJeu() {
     },
 
     secteurCourant: {
-      id: 'ceinture_khepri',
+      id: "ceinture_khepri",
     },
 
-    positionLocale: 'station',
+    positionLocale: "station",
 
     navigation: {
       enVoyage: false,
-      destinationSelectionneeId: 'anneau_demeter',
+      destinationSelectionneeId: "anneau_demeter",
       secteurDestinationId: null,
       ticksRestants: 0,
     },
@@ -112,14 +114,14 @@ export function creerEtatInitialJeu() {
 
     journal: [
       {
-        horodatage: '[T0000]',
-        message: 'Système initialisé.',
-        categorie: 'evenements',
+        horodatage: "[T0000]",
+        message: "Système initialisé.",
+        categorie: "evenements",
       },
       {
-        horodatage: '[T0000]',
-        message: 'Vaisseau prêt au départ, amarré à la station locale.',
-        categorie: 'evenements',
+        horodatage: "[T0000]",
+        message: "Vaisseau prêt au départ, amarré à la station locale.",
+        categorie: "evenements",
       },
     ],
 
@@ -131,5 +133,5 @@ export function creerEtatInitialJeu() {
     technique: {
       compteurTicks: 0,
     },
-  }
+  };
 }

--- a/src/game/systemeAmeliorations.js
+++ b/src/game/systemeAmeliorations.js
@@ -1,149 +1,190 @@
-import { recupererEtatJeu } from './etatJeu'
-import { donneesSecteurs } from './dataSecteurs'
-import { donneesVaisseaux } from './dataVaisseaux'
-import { ajouterAuJournal } from './systemeMinage'
+import { recupererEtatJeu } from "./etatJeu";
+import { donneesSecteurs } from "./dataSecteurs";
+import { donneesVaisseaux } from "./dataVaisseaux";
+import { ajouterAuJournal } from "./systemeMinage";
 
 function recupererSecteurCourant() {
-  const etat = recupererEtatJeu()
+  const etat = recupererEtatJeu();
 
-  return donneesSecteurs.find((secteur) => secteur.id === etat.secteurCourant.id) || null
+  return (
+    donneesSecteurs.find((secteur) => secteur.id === etat.secteurCourant.id) ||
+    null
+  );
 }
 
 function recupererModeleVaisseau() {
-  const etat = recupererEtatJeu()
-  const identifiantModele = etat.vaisseau?.modeleId || etat.vaisseau?.id
+  const etat = recupererEtatJeu();
+  const identifiantModele = etat.vaisseau?.modeleId || etat.vaisseau?.id;
 
-  return donneesVaisseaux.find((vaisseau) => vaisseau.id === identifiantModele) || null
+  return (
+    donneesVaisseaux.find((vaisseau) => vaisseau.id === identifiantModele) ||
+    null
+  );
 }
 
 export function recupererListeAmeliorationsDisponibles() {
-  const modele = recupererModeleVaisseau()
+  const modele = recupererModeleVaisseau();
 
   if (!modele?.ameliorations) {
-    return []
+    return [];
   }
 
-  return modele.ameliorations
+  return modele.ameliorations;
 }
 
 export function ameliorerVaisseau(idAmelioration) {
-  const etat = recupererEtatJeu()
-  const secteurCourant = recupererSecteurCourant()
-  const station = secteurCourant?.stationPrincipale
-  const modele = recupererModeleVaisseau()
+  const etat = recupererEtatJeu();
+  const secteurCourant = recupererSecteurCourant();
+  const station = secteurCourant?.stationPrincipale;
+  const modele = recupererModeleVaisseau();
 
   if (etat.navigation?.enVoyage) {
-    ajouterAuJournal('Impossible de modifier le vaisseau pendant un trajet.', 'commerce', 'alerte')
-    return
+    ajouterAuJournal(
+      "Impossible de modifier le vaisseau pendant un trajet.",
+      "commerce",
+      "alerte",
+    );
+    return;
   }
 
-  if (etat.positionLocale !== 'station') {
-    ajouterAuJournal('Les améliorations ne sont disponibles qu’à la station.', 'commerce', 'alerte')
-    return
+  if (etat.positionLocale !== "station") {
+    ajouterAuJournal(
+      "Les améliorations ne sont disponibles qu’à la station.",
+      "commerce",
+      "alerte",
+    );
+    return;
   }
 
   if (!station?.services?.atelier) {
-    ajouterAuJournal('Aucun atelier disponible dans cette station.', 'commerce', 'alerte')
-    return
+    ajouterAuJournal(
+      "Aucun atelier disponible dans cette station.",
+      "commerce",
+      "alerte",
+    );
+    return;
   }
 
-  const amelioration = modele?.ameliorations?.find((entree) => entree.id === idAmelioration)
+  const amelioration = modele?.ameliorations?.find(
+    (entree) => entree.id === idAmelioration,
+  );
 
   if (!amelioration) {
-    ajouterAuJournal('Amélioration inconnue.', 'commerce', 'alerte')
-    return
+    ajouterAuJournal("Amélioration inconnue.", "commerce", "alerte");
+    return;
   }
 
   if (etat.ressources.credits < amelioration.cout) {
     ajouterAuJournal(
       `Crédits insuffisants pour ${amelioration.nom.toLowerCase()}.`,
-      'commerce',
-      'alerte',
-    )
-    return
+      "commerce",
+      "alerte",
+    );
+    return;
   }
 
-  if (idAmelioration === 'soute') {
+  if (idAmelioration === "soute") {
     if (etat.vaisseau.souteMax >= amelioration.valeurMax) {
-      ajouterAuJournal('Capacité maximale de soute déjà atteinte.', 'commerce', 'alerte')
-      return
+      ajouterAuJournal(
+        "Capacité maximale de soute déjà atteinte.",
+        "commerce",
+        "alerte",
+      );
+      return;
     }
 
-    etat.ressources.credits -= amelioration.cout
+    etat.ressources.credits -= amelioration.cout;
     etat.vaisseau.souteMax = Math.min(
       etat.vaisseau.souteMax + amelioration.increment,
       amelioration.valeurMax,
-    )
+    );
 
     ajouterAuJournal(
       `Amélioration installée : ${amelioration.nom} (${etat.vaisseau.souteMax} max).`,
-      'commerce',
-      'succes',
-    )
-    return
+      "commerce",
+      "succes",
+    );
+    return;
   }
 
-  if (idAmelioration === 'drones') {
+  if (idAmelioration === "drones") {
     if (etat.vaisseau.dronesMiniersMax >= amelioration.valeurMax) {
-      ajouterAuJournal('Capacité maximale de drones déjà atteinte.', 'commerce', 'alerte')
-      return
+      ajouterAuJournal(
+        "Capacité maximale de drones déjà atteinte.",
+        "commerce",
+        "alerte",
+      );
+      return;
     }
 
-    etat.ressources.credits -= amelioration.cout
+    etat.ressources.credits -= amelioration.cout;
     etat.vaisseau.dronesMiniersMax = Math.min(
       etat.vaisseau.dronesMiniersMax + amelioration.increment,
       amelioration.valeurMax,
-    )
+    );
 
     ajouterAuJournal(
       `Amélioration installée : ${amelioration.nom} (${etat.vaisseau.dronesMiniersMax} max).`,
-      'commerce',
-      'succes',
-    )
-    return
+      "commerce",
+      "succes",
+    );
+    return;
   }
 
-  if (idAmelioration === 'carburant') {
+  if (idAmelioration === "carburant") {
     if (etat.vaisseau.carburantMax >= amelioration.valeurMax) {
-      ajouterAuJournal('Capacité maximale de carburant déjà atteinte.', 'commerce', 'alerte')
-      return
+      ajouterAuJournal(
+        "Capacité maximale de carburant déjà atteinte.",
+        "commerce",
+        "alerte",
+      );
+      return;
     }
 
-    etat.ressources.credits -= amelioration.cout
+    etat.ressources.credits -= amelioration.cout;
 
-    const ancienneValeur = etat.vaisseau.carburantMax
+    const ancienneValeur = etat.vaisseau.carburantMax;
+
     etat.vaisseau.carburantMax = Math.min(
       etat.vaisseau.carburantMax + amelioration.increment,
       amelioration.valeurMax,
-    )
+    );
 
-    const gainEffectif = etat.vaisseau.carburantMax - ancienneValeur
-    etat.ressources.carburant += gainEffectif
+    const gainEffectif = etat.vaisseau.carburantMax - ancienneValeur;
+
+    etat.vaisseau.carburant = Math.min(
+      Number(etat.vaisseau.carburant || 0) + gainEffectif,
+      etat.vaisseau.carburantMax,
+    );
 
     ajouterAuJournal(
       `Amélioration installée : ${amelioration.nom} (${etat.vaisseau.carburantMax} max).`,
-      'commerce',
-      'succes',
-    )
-    return
+      "commerce",
+      "succes",
+    );
+    return;
   }
 
-  if (idAmelioration === 'extraction') {
+  if (idAmelioration === "extraction") {
     if (etat.vaisseau.puissanceMiniere >= amelioration.valeurMax) {
-      ajouterAuJournal('Puissance minière maximale déjà atteinte.', 'commerce', 'alerte')
-      return
+      ajouterAuJournal(
+        "Puissance minière maximale déjà atteinte.",
+        "commerce",
+        "alerte",
+      );
+      return;
     }
 
-    etat.ressources.credits -= amelioration.cout
+    etat.ressources.credits -= amelioration.cout;
     etat.vaisseau.puissanceMiniere = Math.min(
       etat.vaisseau.puissanceMiniere + amelioration.increment,
       amelioration.valeurMax,
-    )
+    );
 
     ajouterAuJournal(
       `Amélioration installée : ${amelioration.nom} (${etat.vaisseau.puissanceMiniere} puissance).`,
-      'commerce',
-      'succes',
-    )
+      "commerce",
+      "succes",
+    );
   }
 }

--- a/src/game/systemeAssistance.js
+++ b/src/game/systemeAssistance.js
@@ -1,80 +1,100 @@
-import { recupererEtatJeu } from './etatJeu'
-import { donneesSecteurs } from './dataSecteurs'
-import { calculerTauxTaxePourSecurite } from './systemeCommerce'
-import { ajouterAuJournal, rappelerDrones } from './systemeMinage'
+import { recupererEtatJeu } from "./etatJeu";
+import { donneesSecteurs } from "./dataSecteurs";
+import { calculerTauxTaxePourSecurite } from "./systemeCommerce";
+import { ajouterAuJournal, rappelerDrones } from "./systemeMinage";
+import {
+  recupererVaisseauActif,
+  synchroniserVaisseauActifDansEtat,
+} from "./systemeVaisseaux";
 
 export function verifierPanneSecheEtDeclencher() {
-  const etat = recupererEtatJeu()
+  const etat = recupererEtatJeu();
+  const vaisseauActif = recupererVaisseauActif(etat);
+
+  if (!vaisseauActif) {
+    return;
+  }
 
   if (etat.assistance?.remorquageEnCours) {
-    return
+    return;
   }
 
   if (etat.navigation?.enVoyage) {
-    return
+    return;
   }
 
-  if (etat.positionLocale === 'station') {
-    return
+  if (etat.positionLocale === "station") {
+    return;
   }
 
-  if (etat.ressources.carburant > 0) {
-    return
+  if (vaisseauActif.carburant > 0) {
+    return;
   }
 
-  const secteur = donneesSecteurs.find((s) => s.id === etat.secteurCourant.id)
-  const stationNom = secteur?.stationPrincipale?.nom || 'station locale'
+  const secteur = donneesSecteurs.find((s) => s.id === etat.secteurCourant.id);
+  const stationNom = secteur?.stationPrincipale?.nom || "station locale";
 
-  rappelerDrones(true)
+  rappelerDrones(true);
 
-  etat.assistance.remorquageEnCours = true
-  etat.assistance.ticksRestants = 4
-  etat.assistance.stationCibleNom = stationNom
+  vaisseauActif.carburant = 0;
+  synchroniserVaisseauActifDansEtat(etat);
 
-  ajouterAuJournal('Propulsion indisponible : carburant épuisé.', 'evenements', 'critique')
+  etat.assistance.remorquageEnCours = true;
+  etat.assistance.ticksRestants = 4;
+  etat.assistance.stationCibleNom = stationNom;
+
   ajouterAuJournal(
-    'Assistance orbitale requise. Service de remorquage déclenché.',
-    'evenements',
-    'critique',
-  )
-  ajouterAuJournal(`Remorquage estimé : 4 ticks jusqu’à ${stationNom}.`, 'evenements', 'critique')
+    "Propulsion indisponible : carburant épuisé.",
+    "evenements",
+    "critique",
+  );
+  ajouterAuJournal(
+    "Assistance orbitale requise. Service de remorquage déclenché.",
+    "evenements",
+    "critique",
+  );
+  ajouterAuJournal(
+    `Remorquage estimé : 4 ticks jusqu’à ${stationNom}.`,
+    "evenements",
+    "critique",
+  );
 }
 
 export function faireAvancerRemorquage() {
-  const etat = recupererEtatJeu()
+  const etat = recupererEtatJeu();
 
   if (!etat.assistance?.remorquageEnCours) {
-    return
+    return;
   }
 
-  etat.assistance.ticksRestants -= 1
+  etat.assistance.ticksRestants -= 1;
 
   if (etat.assistance.ticksRestants > 0) {
-    return
+    return;
   }
 
-  const secteur = donneesSecteurs.find((s) => s.id === etat.secteurCourant.id)
-  const station = secteur?.stationPrincipale
-  const tauxTaxe = calculerTauxTaxePourSecurite(secteur?.securite ?? 1)
-  const coutBase = etat.assistance.coutBase ?? 5
-  const taxe = Math.floor(coutBase * tauxTaxe)
-  const coutFinal = coutBase + taxe
+  const secteur = donneesSecteurs.find((s) => s.id === etat.secteurCourant.id);
+  const station = secteur?.stationPrincipale;
+  const tauxTaxe = calculerTauxTaxePourSecurite(secteur?.securite ?? 1);
+  const coutBase = etat.assistance.coutBase ?? 5;
+  const taxe = Math.floor(coutBase * tauxTaxe);
+  const coutFinal = coutBase + taxe;
 
-  etat.ressources.credits -= coutFinal
-  etat.positionLocale = 'station'
-  etat.assistance.remorquageEnCours = false
-  etat.assistance.ticksRestants = 0
-  etat.assistance.stationCibleNom = null
-  etat.exploration.siteActif = null
+  etat.ressources.credits -= coutFinal;
+  etat.positionLocale = "station";
+  etat.assistance.remorquageEnCours = false;
+  etat.assistance.ticksRestants = 0;
+  etat.assistance.stationCibleNom = null;
+  etat.exploration.siteActif = null;
 
   ajouterAuJournal(
-    `Remorquage terminé. Vaisseau amarré à ${station?.nom || 'la station locale'}.`,
-    'commerce',
-    'info',
-  )
+    `Remorquage terminé. Vaisseau amarré à ${station?.nom || "la station locale"}.`,
+    "commerce",
+    "info",
+  );
   ajouterAuJournal(
     `Frais d’assistance : ${coutBase} cr + ${taxe} cr de taxe = ${coutFinal} cr.`,
-    'commerce',
-    'alerte',
-  )
+    "commerce",
+    "alerte",
+  );
 }

--- a/src/game/systemeLocalisation.js
+++ b/src/game/systemeLocalisation.js
@@ -1,98 +1,135 @@
-import { recupererEtatJeu } from './etatJeu'
-import { ajouterAuJournal, rappelerDrones } from './systemeMinage'
-import { avancerTemps } from './systemeTemps'
-import { verifierPanneSecheEtDeclencher } from './systemeAssistance'
+import { recupererEtatJeu } from "./etatJeu";
+import { ajouterAuJournal, rappelerDrones } from "./systemeMinage";
+import { avancerTemps } from "./systemeTemps";
+import { verifierPanneSecheEtDeclencher } from "./systemeAssistance";
+import {
+  recupererVaisseauActif,
+  synchroniserVaisseauActifDansEtat,
+} from "./systemeVaisseaux";
 
-const COUT_CARBURANT_LOCAL = 1
-const COUT_TICKS_LOCAL = 1
+const COUT_CARBURANT_LOCAL = 1;
+const COUT_TICKS_LOCAL = 1;
 
 export function allerEnZoneOperations() {
-  const etat = recupererEtatJeu()
+  const etat = recupererEtatJeu();
+  const vaisseauActif = recupererVaisseauActif(etat);
+
+  if (!vaisseauActif) {
+    ajouterAuJournal(
+      "Aucun vaisseau actif disponible.",
+      "evenements",
+      "alerte",
+    );
+    return;
+  }
 
   if (etat.navigation?.enVoyage) {
     ajouterAuJournal(
-      'Impossible de quitter la station pendant un trajet inter-sectoriel.',
-      'evenements',
-      'alerte',
-    )
-    return
+      "Impossible de quitter la station pendant un trajet inter-sectoriel.",
+      "evenements",
+      "alerte",
+    );
+    return;
   }
 
   if (etat.assistance?.remorquageEnCours) {
     ajouterAuJournal(
-      'Impossible de quitter la station pendant un remorquage.',
-      'evenements',
-      'alerte',
-    )
-    return
+      "Impossible de quitter la station pendant un remorquage.",
+      "evenements",
+      "alerte",
+    );
+    return;
   }
 
-  if (etat.positionLocale === 'operations') {
-    ajouterAuJournal('Le vaisseau est déjà en zone d’opérations.', 'evenements', 'alerte')
-    return
-  }
-
-  if (etat.ressources.carburant < COUT_CARBURANT_LOCAL) {
+  if (etat.positionLocale === "operations") {
     ajouterAuJournal(
-      'Carburant insuffisant pour rejoindre la zone d’opérations.',
-      'evenements',
-      'alerte',
-    )
-    return
+      "Le vaisseau est déjà en zone d’opérations.",
+      "evenements",
+      "alerte",
+    );
+    return;
   }
 
-  etat.ressources.carburant -= COUT_CARBURANT_LOCAL
-  avancerTemps(COUT_TICKS_LOCAL)
-  etat.positionLocale = 'operations'
+  if (vaisseauActif.carburant < COUT_CARBURANT_LOCAL) {
+    ajouterAuJournal(
+      "Carburant insuffisant pour rejoindre la zone d’opérations.",
+      "evenements",
+      "alerte",
+    );
+    return;
+  }
 
-  verifierPanneSecheEtDeclencher()
+  vaisseauActif.carburant -= COUT_CARBURANT_LOCAL;
+  synchroniserVaisseauActifDansEtat(etat);
+
+  avancerTemps(COUT_TICKS_LOCAL);
+  etat.positionLocale = "operations";
+
+  verifierPanneSecheEtDeclencher();
 
   if (!etat.assistance.remorquageEnCours) {
     ajouterAuJournal(
-      'Décollage de la station vers la zone d’opérations locale.',
-      'evenements',
-      'info',
-    )
+      "Décollage de la station vers la zone d’opérations locale.",
+      "evenements",
+      "info",
+    );
   }
 }
 
 export function retourALaStation() {
-  const etat = recupererEtatJeu()
+  const etat = recupererEtatJeu();
+  const vaisseauActif = recupererVaisseauActif(etat);
+
+  if (!vaisseauActif) {
+    ajouterAuJournal(
+      "Aucun vaisseau actif disponible.",
+      "evenements",
+      "alerte",
+    );
+    return;
+  }
 
   if (etat.navigation?.enVoyage) {
     ajouterAuJournal(
-      'Impossible de retourner à la station pendant un trajet inter-sectoriel.',
-      'evenements',
-      'alerte',
-    )
-    return
+      "Impossible de retourner à la station pendant un trajet inter-sectoriel.",
+      "evenements",
+      "alerte",
+    );
+    return;
   }
 
   if (etat.assistance?.remorquageEnCours) {
-    ajouterAuJournal('Remorquage déjà en cours.', 'evenements', 'alerte')
-    return
+    ajouterAuJournal("Remorquage déjà en cours.", "evenements", "alerte");
+    return;
   }
 
-  if (etat.positionLocale === 'station') {
-    ajouterAuJournal('Le vaisseau est déjà amarré à la station.', 'evenements', 'alerte')
-    return
+  if (etat.positionLocale === "station") {
+    ajouterAuJournal(
+      "Le vaisseau est déjà amarré à la station.",
+      "evenements",
+      "alerte",
+    );
+    return;
   }
 
-  if (etat.ressources.carburant < COUT_CARBURANT_LOCAL) {
-    etat.ressources.carburant = 0
-    verifierPanneSecheEtDeclencher()
-    return
+  if (vaisseauActif.carburant < COUT_CARBURANT_LOCAL) {
+    vaisseauActif.carburant = 0;
+    synchroniserVaisseauActifDansEtat(etat);
+    verifierPanneSecheEtDeclencher();
+    return;
   }
 
-  rappelerDrones(true)
+  rappelerDrones(true);
 
-  etat.ressources.carburant -= COUT_CARBURANT_LOCAL
-  avancerTemps(COUT_TICKS_LOCAL)
-  etat.positionLocale = 'station'
+  vaisseauActif.carburant -= COUT_CARBURANT_LOCAL;
+  synchroniserVaisseauActifDansEtat(etat);
+
+  avancerTemps(COUT_TICKS_LOCAL);
+  etat.positionLocale = "station";
 
   ajouterAuJournal(
-    'Retour à la station locale et procédure d’amarrage terminée.',
-    'evenements',
-    'info',
-  )
+    "Retour à la station locale et procédure d’amarrage terminée.",
+    "evenements",
+    "info",
+  );
 }

--- a/src/game/systemeNavigation.js
+++ b/src/game/systemeNavigation.js
@@ -1,133 +1,172 @@
-import { recupererEtatJeu } from './etatJeu'
-import { donneesSecteurs } from './dataSecteurs'
-import { donneesTrajets } from './dataTrajets'
-import { ajouterAuJournal, rappelerDrones } from './systemeMinage'
-import { recupererInformationsCoqueVaisseauActif } from './systemeVaisseaux'
+import { recupererEtatJeu } from "./etatJeu";
+import { donneesSecteurs } from "./dataSecteurs";
+import { donneesTrajets } from "./dataTrajets";
+import { ajouterAuJournal, rappelerDrones } from "./systemeMinage";
+import {
+  recupererInformationsCoqueVaisseauActif,
+  recupererVaisseauActif,
+  synchroniserVaisseauActifDansEtat,
+} from "./systemeVaisseaux";
 
 export function recupererSecteurParId(idSecteur) {
-  return donneesSecteurs.find((secteur) => secteur.id === idSecteur) || null
+  return donneesSecteurs.find((secteur) => secteur.id === idSecteur) || null;
 }
 
 export function recupererSecteurCourant() {
-  const etat = recupererEtatJeu()
-  return recupererSecteurParId(etat.secteurCourant.id)
+  const etat = recupererEtatJeu();
+  return recupererSecteurParId(etat.secteurCourant.id);
 }
 
 export function recupererTrajet(idOrigine, idDestination) {
   return (
-      donneesTrajets.find(
-          (trajet) => trajet.origine === idOrigine && trajet.destination === idDestination,
-      ) || null
-  )
+    donneesTrajets.find(
+      (trajet) =>
+        trajet.origine === idOrigine && trajet.destination === idDestination,
+    ) || null
+  );
 }
 
 export function selectionnerDestination(idDestination) {
-  const etat = recupererEtatJeu()
-  etat.navigation.destinationSelectionneeId = idDestination
+  const etat = recupererEtatJeu();
+  etat.navigation.destinationSelectionneeId = idDestination;
 }
 
 export function lancerVoyageVersDestinationSelectionnee() {
-  const etat = recupererEtatJeu()
-  const infosCoque = recupererInformationsCoqueVaisseauActif(etat)
+  const etat = recupererEtatJeu();
+  const infosCoque = recupererInformationsCoqueVaisseauActif(etat);
+  const vaisseauActif = recupererVaisseauActif(etat);
 
-  if (infosCoque.code === 'hors_service') {
+  if (!vaisseauActif) {
     ajouterAuJournal(
-        'Coque hors service : déplacement inter-sectoriel impossible.',
-        'evenements',
-        'critique',
-    )
-    return
+      "Aucun vaisseau actif disponible.",
+      "evenements",
+      "alerte",
+    );
+    return;
+  }
+
+  if (infosCoque.code === "hors_service") {
+    ajouterAuJournal(
+      "Coque hors service : déplacement inter-sectoriel impossible.",
+      "evenements",
+      "critique",
+    );
+    return;
   }
 
   if (etat.assistance?.remorquageEnCours) {
-    ajouterAuJournal('Voyage impossible pendant un remorquage.', 'evenements', 'alerte')
-    return
+    ajouterAuJournal(
+      "Voyage impossible pendant un remorquage.",
+      "evenements",
+      "alerte",
+    );
+    return;
   }
 
   if (etat.navigation.enVoyage) {
-    ajouterAuJournal('Navigation déjà en cours.', 'evenements', 'alerte')
-    return
+    ajouterAuJournal("Navigation déjà en cours.", "evenements", "alerte");
+    return;
   }
 
-  if (etat.positionLocale !== 'station') {
+  if (etat.positionLocale !== "station") {
     ajouterAuJournal(
-        'Le voyage inter-sectoriel ne peut être lancé que depuis la station.',
-        'evenements',
-        'alerte',
-    )
-    return
+      "Le voyage inter-sectoriel ne peut être lancé que depuis la station.",
+      "evenements",
+      "alerte",
+    );
+    return;
   }
 
-  const idOrigine = etat.secteurCourant.id
-  const idDestination = etat.navigation.destinationSelectionneeId
+  const idOrigine = etat.secteurCourant.id;
+  const idDestination = etat.navigation.destinationSelectionneeId;
 
   if (!idDestination) {
-    ajouterAuJournal('Aucune destination sélectionnée.', 'evenements', 'alerte')
-    return
+    ajouterAuJournal(
+      "Aucune destination sélectionnée.",
+      "evenements",
+      "alerte",
+    );
+    return;
   }
 
   if (idOrigine === idDestination) {
-    ajouterAuJournal('Vous êtes déjà dans ce secteur.', 'evenements', 'alerte')
-    return
+    ajouterAuJournal("Vous êtes déjà dans ce secteur.", "evenements", "alerte");
+    return;
   }
 
-  const secteurDestination = recupererSecteurParId(idDestination)
-  const trajet = recupererTrajet(idOrigine, idDestination)
+  const secteurDestination = recupererSecteurParId(idDestination);
+  const trajet = recupererTrajet(idOrigine, idDestination);
 
   if (!secteurDestination || !trajet) {
-    ajouterAuJournal('Aucun trajet disponible vers cette destination.', 'evenements', 'alerte')
-    return
+    ajouterAuJournal(
+      "Aucun trajet disponible vers cette destination.",
+      "evenements",
+      "alerte",
+    );
+    return;
   }
 
-  if (etat.ressources.carburant < trajet.coutCarburant) {
-    ajouterAuJournal('Carburant insuffisant pour effectuer ce trajet.', 'evenements', 'alerte')
-    return
+  if (vaisseauActif.carburant < trajet.coutCarburant) {
+    ajouterAuJournal(
+      "Carburant insuffisant pour effectuer ce trajet.",
+      "evenements",
+      "alerte",
+    );
+    return;
   }
 
-  rappelerDrones(true)
+  rappelerDrones(true);
 
-  etat.ressources.carburant -= trajet.coutCarburant
-  etat.navigation.enVoyage = true
-  etat.navigation.secteurDestinationId = idDestination
-  etat.navigation.ticksRestants = trajet.tempsTrajet
-  etat.exploration.siteActif = null
+  vaisseauActif.carburant -= trajet.coutCarburant;
+  synchroniserVaisseauActifDansEtat(etat);
+
+  etat.navigation.enVoyage = true;
+  etat.navigation.secteurDestinationId = idDestination;
+  etat.navigation.ticksRestants = trajet.tempsTrajet;
+  etat.exploration.siteActif = null;
 
   ajouterAuJournal(
-      `Départ vers ${secteurDestination.nom} — coût ${trajet.coutCarburant} carburant, durée ${trajet.tempsTrajet} ticks.`,
-      'evenements',
-      'info',
-  )
+    `Départ vers ${secteurDestination.nom} — coût ${trajet.coutCarburant} carburant, durée ${trajet.tempsTrajet} ticks.`,
+    "evenements",
+    "info",
+  );
 }
 
 export function faireAvancerVoyage() {
-  const etat = recupererEtatJeu()
+  const etat = recupererEtatJeu();
 
   if (!etat.navigation.enVoyage) {
-    return
+    return;
   }
 
-  etat.navigation.ticksRestants -= 1
+  etat.navigation.ticksRestants -= 1;
 
   if (etat.navigation.ticksRestants > 0) {
-    return
+    return;
   }
 
-  const secteurDestination = recupererSecteurParId(etat.navigation.secteurDestinationId)
+  const secteurDestination = recupererSecteurParId(
+    etat.navigation.secteurDestinationId,
+  );
 
-  etat.secteurCourant.id = etat.navigation.secteurDestinationId
-  etat.navigation.enVoyage = false
-  etat.navigation.secteurDestinationId = null
-  etat.navigation.ticksRestants = 0
-  etat.positionLocale = 'station'
-  etat.exploration.siteActif = null
+  etat.secteurCourant.id = etat.navigation.secteurDestinationId;
+  etat.navigation.enVoyage = false;
+  etat.navigation.secteurDestinationId = null;
+  etat.navigation.ticksRestants = 0;
+  etat.positionLocale = "station";
+  etat.exploration.siteActif = null;
 
   if (secteurDestination) {
     ajouterAuJournal(
-        `Arrivée dans le secteur ${secteurDestination.nom}. Amarrage local disponible.`,
-        'evenements',
-        'info',
-    )
+      `Arrivée dans le secteur ${secteurDestination.nom}. Amarrage local disponible.`,
+      "evenements",
+      "info",
+    );
   } else {
-    ajouterAuJournal('Arrivée dans le secteur de destination.', 'evenements', 'info')
+    ajouterAuJournal(
+      "Arrivée dans le secteur de destination.",
+      "evenements",
+      "info",
+    );
   }
 }

--- a/src/game/systemeRavitaillement.js
+++ b/src/game/systemeRavitaillement.js
@@ -1,83 +1,118 @@
-import { recupererEtatJeu } from './etatJeu'
-import { donneesSecteurs } from './dataSecteurs'
-import { ajouterAuJournal } from './systemeMinage'
+import { recupererEtatJeu } from "./etatJeu";
+import { donneesSecteurs } from "./dataSecteurs";
+import { ajouterAuJournal } from "./systemeMinage";
+import {
+  recupererVaisseauActif,
+  synchroniserVaisseauActifDansEtat,
+} from "./systemeVaisseaux";
 
 function recupererSecteurCourant() {
-  const etat = recupererEtatJeu()
+  const etat = recupererEtatJeu();
 
-  return donneesSecteurs.find((secteur) => secteur.id === etat.secteurCourant.id) || null
+  return (
+    donneesSecteurs.find((secteur) => secteur.id === etat.secteurCourant.id) ||
+    null
+  );
 }
 
 export function ravitaillerCarburant() {
-  const etat = recupererEtatJeu()
+  const etat = recupererEtatJeu();
+  const vaisseauActif = recupererVaisseauActif(etat);
+
+  if (!vaisseauActif) {
+    ajouterAuJournal(
+      "Aucun vaisseau actif disponible pour le ravitaillement.",
+      "commerce",
+      "alerte",
+    );
+    return;
+  }
 
   if (etat.navigation?.enVoyage) {
     ajouterAuJournal(
-      'Impossible de ravitailler le vaisseau pendant un trajet.',
-      'commerce',
-      'alerte',
-    )
-    return
+      "Impossible de ravitailler le vaisseau pendant un trajet.",
+      "commerce",
+      "alerte",
+    );
+    return;
   }
 
-  if (etat.positionLocale !== 'station') {
-    ajouterAuJournal('Le ravitaillement n’est possible qu’à la station.', 'commerce', 'alerte')
-    return
+  if (etat.positionLocale !== "station") {
+    ajouterAuJournal(
+      "Le ravitaillement n’est possible qu’à la station.",
+      "commerce",
+      "alerte",
+    );
+    return;
   }
 
-  const secteurCourant = recupererSecteurCourant()
-  const station = secteurCourant?.stationPrincipale
+  const secteurCourant = recupererSecteurCourant();
+  const station = secteurCourant?.stationPrincipale;
 
   if (!station?.services?.ravitaillement) {
     ajouterAuJournal(
-      'Aucun service de ravitaillement disponible dans cette station.',
-      'commerce',
-      'alerte',
-    )
-    return
+      "Aucun service de ravitaillement disponible dans cette station.",
+      "commerce",
+      "alerte",
+    );
+    return;
   }
 
-  const carburantManquant = etat.vaisseau.carburantMax - etat.ressources.carburant
+  const carburantManquant =
+    vaisseauActif.carburantMax - vaisseauActif.carburant;
 
   if (carburantManquant <= 0) {
-    ajouterAuJournal(`Réservoir déjà plein à ${station.nom}.`, 'commerce', 'info')
-    return
+    ajouterAuJournal(
+      `Réservoir déjà plein à ${station.nom}.`,
+      "commerce",
+      "info",
+    );
+    return;
   }
 
-  const prixParUnite = station.economie?.coutCarburantParUnite ?? 1
+  const prixParUnite = station.economie?.coutCarburantParUnite ?? 1;
 
   if (etat.ressources.credits <= 0) {
-    ajouterAuJournal('Crédits insuffisants pour procéder au ravitaillement.', 'commerce', 'alerte')
-    return
+    ajouterAuJournal(
+      "Crédits insuffisants pour procéder au ravitaillement.",
+      "commerce",
+      "alerte",
+    );
+    return;
   }
 
   const unitesAchetables = Math.min(
     carburantManquant,
     Math.floor(etat.ressources.credits / prixParUnite),
-  )
+  );
 
   if (unitesAchetables <= 0) {
-    ajouterAuJournal('Crédits insuffisants pour procéder au ravitaillement.', 'commerce', 'alerte')
-    return
+    ajouterAuJournal(
+      "Crédits insuffisants pour procéder au ravitaillement.",
+      "commerce",
+      "alerte",
+    );
+    return;
   }
 
-  const coutFinal = unitesAchetables * prixParUnite
+  const coutFinal = unitesAchetables * prixParUnite;
 
-  etat.ressources.credits -= coutFinal
-  etat.ressources.carburant += unitesAchetables
+  etat.ressources.credits -= coutFinal;
+  vaisseauActif.carburant += unitesAchetables;
+  synchroniserVaisseauActifDansEtat(etat);
 
   if (unitesAchetables === carburantManquant) {
     ajouterAuJournal(
       `Ravitaillement terminé à ${station.nom} : +${unitesAchetables} carburant pour ${coutFinal} crédits.`,
-      'commerce',
-      'succes',
-    )
-    return
+      "commerce",
+      "succes",
+    );
+    return;
   }
 
   ajouterAuJournal(
     `Ravitaillement partiel à ${station.nom} : +${unitesAchetables} carburant pour ${coutFinal} crédits.`,
-    'commerce',
-    'succes',
-  )
+    "commerce",
+    "succes",
+  );
 }

--- a/src/game/systemeVaisseaux.js
+++ b/src/game/systemeVaisseaux.js
@@ -1,62 +1,74 @@
-import { donneesVaisseaux } from './dataVaisseaux'
-import { recupererEtatJeu } from './etatJeu'
-import { recupererTickCourant } from './systemeTemps'
-import { recupererEtatCoque } from './systemeCoque'
+import { donneesVaisseaux } from "./dataVaisseaux";
+import { recupererEtatJeu } from "./etatJeu";
+import { recupererTickCourant } from "./systemeTemps";
+import { recupererEtatCoque } from "./systemeCoque";
 
-export const DUREE_CONTRAT_ASSURANCE_TICKS = 720
+export const DUREE_CONTRAT_ASSURANCE_TICKS = 720;
 
 function obtenirHorodatageTick() {
-  const tick = recupererTickCourant()
-  return `[T${String(tick).padStart(4, '0')}]`
+  const tick = recupererTickCourant();
+  return `[T${String(tick).padStart(4, "0")}]`;
 }
 
-function ajouterAuJournal(message, categorie = 'evenements') {
-  const etat = recupererEtatJeu()
+function ajouterAuJournal(message, categorie = "evenements") {
+  const etat = recupererEtatJeu();
 
   etat.journal.unshift({
     horodatage: obtenirHorodatageTick(),
     message,
     categorie,
-  })
+  });
 
   if (etat.journal.length > 50) {
-    etat.journal.pop()
+    etat.journal.pop();
   }
 }
 
 function bornerValeur(valeur, minimum, maximum) {
-  return Math.min(Math.max(valeur, minimum), maximum)
+  return Math.min(Math.max(valeur, minimum), maximum);
+}
+
+function supprimerCarburantRessourcesLegacy(etat) {
+  if (
+    etat?.ressources &&
+    Object.prototype.hasOwnProperty.call(etat.ressources, "carburant")
+  ) {
+    delete etat.ressources.carburant;
+  }
 }
 
 function recupererLibelleAssurance(niveau) {
   switch (niveau) {
-    case 'tiers':
-      return 'au tiers'
-    case 'standard':
-      return 'standard'
-    case 'premium':
-      return 'premium'
-    case 'elite':
-      return 'élite'
+    case "tiers":
+      return "au tiers";
+    case "standard":
+      return "standard";
+    case "premium":
+      return "premium";
+    case "elite":
+      return "élite";
     default:
-      return 'aucune'
+      return "aucune";
   }
 }
 
-function estContratAssuranceActif(vaisseau, tickCourant = recupererTickCourant()) {
-  const niveau = vaisseau?.assuranceNiveau || 'aucune'
-  const expiration = Number(vaisseau?.assuranceExpirationTick || 0)
+function estContratAssuranceActif(
+  vaisseau,
+  tickCourant = recupererTickCourant(),
+) {
+  const niveau = vaisseau?.assuranceNiveau || "aucune";
+  const expiration = Number(vaisseau?.assuranceExpirationTick || 0);
 
-  if (niveau === 'aucune') {
-    return false
+  if (niveau === "aucune") {
+    return false;
   }
 
-  return expiration > tickCourant
+  return expiration > tickCourant;
 }
 
 function calculerCoutAssurance(modeleId, niveau) {
-  const modele = donneesVaisseaux.find((entree) => entree.id === modeleId)
-  const valeurMarchande = Number(modele?.prix || 0)
+  const modele = donneesVaisseaux.find((entree) => entree.id === modeleId);
+  const valeurMarchande = Number(modele?.prix || 0);
 
   const multiplicateurs = {
     aucune: 0,
@@ -64,50 +76,55 @@ function calculerCoutAssurance(modeleId, niveau) {
     standard: 0.07,
     premium: 0.11,
     elite: 0.16,
-  }
+  };
 
-  return Math.max(0, Math.round(valeurMarchande * (multiplicateurs[niveau] || 0)))
+  return Math.max(
+    0,
+    Math.round(valeurMarchande * (multiplicateurs[niveau] || 0)),
+  );
 }
 
 function recupererTauxRemboursementAssurance(niveau) {
   switch (niveau) {
-    case 'tiers':
-      return 0.33
-    case 'standard':
-      return 0.66
-    case 'premium':
-      return 1
-    case 'elite':
-      return 1.25
+    case "tiers":
+      return 0.33;
+    case "standard":
+      return 0.66;
+    case "premium":
+      return 1;
+    case "elite":
+      return 1.25;
     default:
-      return 0
+      return 0;
   }
 }
 
 function recupererValeurMarchandeVaisseau(vaisseau) {
   if (!vaisseau) {
-    return 0
+    return 0;
   }
 
-  const modele = donneesVaisseaux.find((entree) => entree.id === vaisseau.modeleId)
-  return Math.max(0, Number(modele?.prix || 0))
+  const modele = donneesVaisseaux.find(
+    (entree) => entree.id === vaisseau.modeleId,
+  );
+  return Math.max(0, Number(modele?.prix || 0));
 }
 
 function reinitialiserContratAssuranceVaisseau(vaisseau) {
   if (!vaisseau) {
-    return
+    return;
   }
 
-  vaisseau.assuranceNiveau = 'aucune'
-  vaisseau.assuranceSouscriptionTick = 0
-  vaisseau.assuranceExpirationTick = 0
+  vaisseau.assuranceNiveau = "aucune";
+  vaisseau.assuranceSouscriptionTick = 0;
+  vaisseau.assuranceExpirationTick = 0;
 }
 
-export function creerInstanceVaisseauDepuisModele(modeleId, suffixe = '001') {
-  const modele = donneesVaisseaux.find((vaisseau) => vaisseau.id === modeleId)
+export function creerInstanceVaisseauDepuisModele(modeleId, suffixe = "001") {
+  const modele = donneesVaisseaux.find((vaisseau) => vaisseau.id === modeleId);
 
   if (!modele) {
-    throw new Error(`Modèle de vaisseau introuvable : ${modeleId}`)
+    throw new Error(`Modèle de vaisseau introuvable : ${modeleId}`);
   }
 
   return {
@@ -124,32 +141,35 @@ export function creerInstanceVaisseauDepuisModele(modeleId, suffixe = '001') {
     dronesMiniersMax: modele.dronesMiniersMax,
     carburant: modele.carburantMax,
     carburantMax: modele.carburantMax,
-    assuranceNiveau: 'aucune',
+    assuranceNiveau: "aucune",
     assuranceSouscriptionTick: 0,
     assuranceExpirationTick: 0,
     scanner: structuredClone(modele.scanner || {}),
     ameliorations: structuredClone(modele.ameliorations || []),
     ameliorationsMax: structuredClone(modele.ameliorationsMax || {}),
-  }
+  };
 }
 
 export function normaliserVaisseauPossede(vaisseau) {
   if (!vaisseau) {
-    return null
+    return null;
   }
 
   const modele = donneesVaisseaux.find(
     (modeleVaisseau) =>
-      modeleVaisseau.id === vaisseau.modeleId || modeleVaisseau.id === vaisseau.id,
-  )
+      modeleVaisseau.id === vaisseau.modeleId ||
+      modeleVaisseau.id === vaisseau.id,
+  );
 
   if (!modele) {
-    return structuredClone(vaisseau)
+    return structuredClone(vaisseau);
   }
 
-  const coqueMax = Number(vaisseau.coqueMax ?? modele.coqueMax ?? 0)
-  const souteMax = Number(vaisseau.souteMax ?? modele.souteMax ?? 0)
-  const carburantMax = Number(vaisseau.carburantMax ?? modele.carburantMax ?? 0)
+  const coqueMax = Number(vaisseau.coqueMax ?? modele.coqueMax ?? 0);
+  const souteMax = Number(vaisseau.souteMax ?? modele.souteMax ?? 0);
+  const carburantMax = Number(
+    vaisseau.carburantMax ?? modele.carburantMax ?? 0,
+  );
 
   return {
     id: vaisseau.id || `${modele.id}_001`,
@@ -161,104 +181,140 @@ export function normaliserVaisseauPossede(vaisseau) {
     coqueMax,
     soute: bornerValeur(Number(vaisseau.soute ?? 0), 0, souteMax),
     souteMax,
-    puissanceMiniere: Number(vaisseau.puissanceMiniere ?? modele.puissanceMiniere ?? 0),
-    dronesMiniersMax: Number(vaisseau.dronesMiniersMax ?? modele.dronesMiniersMax ?? 0),
-    carburant: bornerValeur(Number(vaisseau.carburant ?? carburantMax), 0, carburantMax),
+    puissanceMiniere: Number(
+      vaisseau.puissanceMiniere ?? modele.puissanceMiniere ?? 0,
+    ),
+    dronesMiniersMax: Number(
+      vaisseau.dronesMiniersMax ?? modele.dronesMiniersMax ?? 0,
+    ),
+    carburant: bornerValeur(
+      Number(vaisseau.carburant ?? carburantMax),
+      0,
+      carburantMax,
+    ),
     carburantMax,
-    assuranceNiveau: vaisseau.assuranceNiveau || 'aucune',
+    assuranceNiveau: vaisseau.assuranceNiveau || "aucune",
     assuranceSouscriptionTick: Number(vaisseau.assuranceSouscriptionTick || 0),
     assuranceExpirationTick: Number(vaisseau.assuranceExpirationTick || 0),
     scanner: structuredClone(vaisseau.scanner || modele.scanner || {}),
-    ameliorations: structuredClone(vaisseau.ameliorations || modele.ameliorations || []),
-    ameliorationsMax: structuredClone(vaisseau.ameliorationsMax || modele.ameliorationsMax || {}),
-  }
+    ameliorations: structuredClone(
+      vaisseau.ameliorations || modele.ameliorations || [],
+    ),
+    ameliorationsMax: structuredClone(
+      vaisseau.ameliorationsMax || modele.ameliorationsMax || {},
+    ),
+  };
 }
 
 export function recupererVaisseauActif(etat = recupererEtatJeu()) {
   if (!etat.vaisseauxPossedes || !etat.vaisseauActifId) {
-    return null
+    return null;
   }
 
-  return etat.vaisseauxPossedes.find((vaisseau) => vaisseau.id === etat.vaisseauActifId) || null
+  return (
+    etat.vaisseauxPossedes.find(
+      (vaisseau) => vaisseau.id === etat.vaisseauActifId,
+    ) || null
+  );
 }
 
 export function recupererInformationsCoqueVaisseau(vaisseau) {
   if (!vaisseau) {
     return {
-      code: 'hors_service',
-      label: 'Hors service',
+      code: "hors_service",
+      label: "Hors service",
       seuilMin: 0,
       seuilMax: 0,
       pourcentage: 0,
-    }
+    };
   }
 
-  return recupererEtatCoque(vaisseau.coque, vaisseau.coqueMax)
+  return recupererEtatCoque(vaisseau.coque, vaisseau.coqueMax);
 }
 
-export function recupererInformationsCoqueVaisseauActif(etat = recupererEtatJeu()) {
-  const vaisseauActif = recupererVaisseauActif(etat)
-  return recupererInformationsCoqueVaisseau(vaisseauActif)
+export function recupererInformationsCoqueVaisseauActif(
+  etat = recupererEtatJeu(),
+) {
+  const vaisseauActif = recupererVaisseauActif(etat);
+  return recupererInformationsCoqueVaisseau(vaisseauActif);
 }
 
-export function synchroniserFlotteDepuisVaisseauActif(etat = recupererEtatJeu()) {
-  const vaisseauActif = recupererVaisseauActif(etat)
+export function synchroniserFlotteDepuisVaisseauActif(
+  etat = recupererEtatJeu(),
+) {
+  const vaisseauActif = recupererVaisseauActif(etat);
 
   if (!vaisseauActif || !etat.vaisseau) {
-    return
+    supprimerCarburantRessourcesLegacy(etat);
+    return;
   }
 
-  vaisseauActif.coqueMax = Number(etat.vaisseau.coqueMax ?? vaisseauActif.coqueMax)
+  vaisseauActif.coqueMax = Number(
+    etat.vaisseau.coqueMax ?? vaisseauActif.coqueMax,
+  );
   vaisseauActif.coque = bornerValeur(
     Number(etat.vaisseau.coque ?? vaisseauActif.coque),
     0,
     vaisseauActif.coqueMax,
-  )
+  );
 
-  vaisseauActif.souteMax = Number(etat.vaisseau.souteMax ?? vaisseauActif.souteMax)
+  vaisseauActif.souteMax = Number(
+    etat.vaisseau.souteMax ?? vaisseauActif.souteMax,
+  );
   vaisseauActif.soute = bornerValeur(
     Number(etat.vaisseau.soute ?? vaisseauActif.soute),
     0,
     vaisseauActif.souteMax,
-  )
+  );
 
   vaisseauActif.puissanceMiniere = Number(
     etat.vaisseau.puissanceMiniere ?? vaisseauActif.puissanceMiniere,
-  )
+  );
   vaisseauActif.dronesMiniersMax = Number(
     etat.vaisseau.dronesMiniersMax ?? vaisseauActif.dronesMiniersMax,
-  )
+  );
 
-  vaisseauActif.carburantMax = Number(etat.vaisseau.carburantMax ?? vaisseauActif.carburantMax)
+  vaisseauActif.carburantMax = Number(
+    etat.vaisseau.carburantMax ?? vaisseauActif.carburantMax,
+  );
   vaisseauActif.carburant = bornerValeur(
-    Number(etat.ressources.carburant ?? vaisseauActif.carburant),
+    Number(etat.vaisseau.carburant ?? vaisseauActif.carburant),
     0,
     vaisseauActif.carburantMax,
-  )
+  );
 
   vaisseauActif.assuranceNiveau =
-    etat.vaisseau.assuranceNiveau || vaisseauActif.assuranceNiveau || 'aucune'
+    etat.vaisseau.assuranceNiveau || vaisseauActif.assuranceNiveau || "aucune";
   vaisseauActif.assuranceSouscriptionTick = Number(
-    etat.vaisseau.assuranceSouscriptionTick ?? vaisseauActif.assuranceSouscriptionTick ?? 0,
-  )
+    etat.vaisseau.assuranceSouscriptionTick ??
+      vaisseauActif.assuranceSouscriptionTick ??
+      0,
+  );
   vaisseauActif.assuranceExpirationTick = Number(
-    etat.vaisseau.assuranceExpirationTick ?? vaisseauActif.assuranceExpirationTick ?? 0,
-  )
+    etat.vaisseau.assuranceExpirationTick ??
+      vaisseauActif.assuranceExpirationTick ??
+      0,
+  );
 
-  vaisseauActif.scanner = structuredClone(etat.vaisseau.scanner || vaisseauActif.scanner || {})
+  vaisseauActif.scanner = structuredClone(
+    etat.vaisseau.scanner || vaisseauActif.scanner || {},
+  );
   vaisseauActif.ameliorations = structuredClone(
     etat.vaisseau.ameliorations || vaisseauActif.ameliorations || [],
-  )
+  );
   vaisseauActif.ameliorationsMax = structuredClone(
     etat.vaisseau.ameliorationsMax || vaisseauActif.ameliorationsMax || {},
-  )
+  );
+
+  supprimerCarburantRessourcesLegacy(etat);
 }
 
 export function synchroniserVaisseauActifDansEtat(etat = recupererEtatJeu()) {
-  const vaisseauActif = recupererVaisseauActif(etat)
+  const vaisseauActif = recupererVaisseauActif(etat);
 
   if (!vaisseauActif) {
-    return
+    supprimerCarburantRessourcesLegacy(etat);
+    return;
   }
 
   etat.vaisseau = {
@@ -273,383 +329,478 @@ export function synchroniserVaisseauActifDansEtat(etat = recupererEtatJeu()) {
     souteMax: vaisseauActif.souteMax,
     puissanceMiniere: vaisseauActif.puissanceMiniere,
     dronesMiniersMax: vaisseauActif.dronesMiniersMax,
+    carburant: vaisseauActif.carburant,
     carburantMax: vaisseauActif.carburantMax,
-    assuranceNiveau: vaisseauActif.assuranceNiveau || 'aucune',
-    assuranceSouscriptionTick: Number(vaisseauActif.assuranceSouscriptionTick || 0),
+    assuranceNiveau: vaisseauActif.assuranceNiveau || "aucune",
+    assuranceSouscriptionTick: Number(
+      vaisseauActif.assuranceSouscriptionTick || 0,
+    ),
     assuranceExpirationTick: Number(vaisseauActif.assuranceExpirationTick || 0),
     scanner: structuredClone(vaisseauActif.scanner || {}),
     ameliorations: structuredClone(vaisseauActif.ameliorations || []),
     ameliorationsMax: structuredClone(vaisseauActif.ameliorationsMax || {}),
-  }
+  };
 
-  etat.ressources.carburant = vaisseauActif.carburant
+  supprimerCarburantRessourcesLegacy(etat);
 }
 
-export function hydraterEtatVaisseauxApresChargement(etat = recupererEtatJeu()) {
-  if (!Array.isArray(etat.vaisseauxPossedes) || etat.vaisseauxPossedes.length === 0) {
-    const modeleId = etat.vaisseau?.modeleId || etat.vaisseau?.id || 'hw_mule'
-    const vaisseauHydrate = creerInstanceVaisseauDepuisModele(modeleId)
+export function hydraterEtatVaisseauxApresChargement(
+  etat = recupererEtatJeu(),
+) {
+  const carburantLegacy =
+    etat.vaisseau?.carburant ?? etat.ressources?.carburant;
 
-    vaisseauHydrate.coque = etat.vaisseau?.coque ?? vaisseauHydrate.coque
-    vaisseauHydrate.soute = etat.vaisseau?.soute ?? vaisseauHydrate.soute
-    vaisseauHydrate.souteMax = etat.vaisseau?.souteMax ?? vaisseauHydrate.souteMax
+  if (
+    !Array.isArray(etat.vaisseauxPossedes) ||
+    etat.vaisseauxPossedes.length === 0
+  ) {
+    const modeleId = etat.vaisseau?.modeleId || etat.vaisseau?.id || "hw_mule";
+    const vaisseauHydrate = creerInstanceVaisseauDepuisModele(modeleId);
+
+    vaisseauHydrate.coque = etat.vaisseau?.coque ?? vaisseauHydrate.coque;
+    vaisseauHydrate.soute = etat.vaisseau?.soute ?? vaisseauHydrate.soute;
+    vaisseauHydrate.souteMax =
+      etat.vaisseau?.souteMax ?? vaisseauHydrate.souteMax;
     vaisseauHydrate.puissanceMiniere =
-      etat.vaisseau?.puissanceMiniere ?? vaisseauHydrate.puissanceMiniere
+      etat.vaisseau?.puissanceMiniere ?? vaisseauHydrate.puissanceMiniere;
     vaisseauHydrate.dronesMiniersMax =
-      etat.vaisseau?.dronesMiniersMax ?? vaisseauHydrate.dronesMiniersMax
-    vaisseauHydrate.carburant = etat.ressources?.carburant ?? vaisseauHydrate.carburant
-    vaisseauHydrate.carburantMax = etat.vaisseau?.carburantMax ?? vaisseauHydrate.carburantMax
+      etat.vaisseau?.dronesMiniersMax ?? vaisseauHydrate.dronesMiniersMax;
+    vaisseauHydrate.carburant = carburantLegacy ?? vaisseauHydrate.carburant;
+    vaisseauHydrate.carburantMax =
+      etat.vaisseau?.carburantMax ?? vaisseauHydrate.carburantMax;
     vaisseauHydrate.assuranceNiveau =
-      etat.vaisseau?.assuranceNiveau ?? vaisseauHydrate.assuranceNiveau
+      etat.vaisseau?.assuranceNiveau ?? vaisseauHydrate.assuranceNiveau;
     vaisseauHydrate.assuranceSouscriptionTick =
-      etat.vaisseau?.assuranceSouscriptionTick ?? vaisseauHydrate.assuranceSouscriptionTick
+      etat.vaisseau?.assuranceSouscriptionTick ??
+      vaisseauHydrate.assuranceSouscriptionTick;
     vaisseauHydrate.assuranceExpirationTick =
-      etat.vaisseau?.assuranceExpirationTick ?? vaisseauHydrate.assuranceExpirationTick
-    vaisseauHydrate.scanner = structuredClone(etat.vaisseau?.scanner || vaisseauHydrate.scanner)
+      etat.vaisseau?.assuranceExpirationTick ??
+      vaisseauHydrate.assuranceExpirationTick;
+    vaisseauHydrate.scanner = structuredClone(
+      etat.vaisseau?.scanner || vaisseauHydrate.scanner,
+    );
     vaisseauHydrate.ameliorations = structuredClone(
       etat.vaisseau?.ameliorations || vaisseauHydrate.ameliorations,
-    )
+    );
     vaisseauHydrate.ameliorationsMax = structuredClone(
       etat.vaisseau?.ameliorationsMax || vaisseauHydrate.ameliorationsMax || {},
-    )
+    );
 
-    etat.vaisseauxPossedes = [normaliserVaisseauPossede(vaisseauHydrate)]
-    etat.vaisseauActifId = etat.vaisseauxPossedes[0].id
+    etat.vaisseauxPossedes = [normaliserVaisseauPossede(vaisseauHydrate)];
+    etat.vaisseauActifId = etat.vaisseauxPossedes[0].id;
   } else {
     etat.vaisseauxPossedes = etat.vaisseauxPossedes
-      .map((vaisseau) => normaliserVaisseauPossede(vaisseau))
-      .filter(Boolean)
+      .map((vaisseau) => {
+        const estVaisseauActifLegacy =
+          vaisseau.id === etat.vaisseauActifId ||
+          (!etat.vaisseauActifId && vaisseau.id === etat.vaisseau?.id);
+
+        if (
+          estVaisseauActifLegacy &&
+          vaisseau.carburant === undefined &&
+          carburantLegacy !== undefined
+        ) {
+          return normaliserVaisseauPossede({
+            ...vaisseau,
+            carburant: carburantLegacy,
+          });
+        }
+
+        return normaliserVaisseauPossede(vaisseau);
+      })
+      .filter(Boolean);
   }
 
   if (!etat.vaisseauActifId && etat.vaisseauxPossedes.length > 0) {
-    etat.vaisseauActifId = etat.vaisseauxPossedes[0].id
+    etat.vaisseauActifId = etat.vaisseauxPossedes[0].id;
   }
 
-  const vaisseauActif = recupererVaisseauActif(etat)
+  const vaisseauActif = recupererVaisseauActif(etat);
 
   if (!vaisseauActif && etat.vaisseauxPossedes.length > 0) {
-    etat.vaisseauActifId = etat.vaisseauxPossedes[0].id
+    etat.vaisseauActifId = etat.vaisseauxPossedes[0].id;
   }
 
   if (!etat.ressources.cargaisonMarchande) {
-    etat.ressources.cargaisonMarchande = {}
+    etat.ressources.cargaisonMarchande = {};
   }
 
-  synchroniserVaisseauActifDansEtat(etat)
+  synchroniserVaisseauActifDansEtat(etat);
+  supprimerCarburantRessourcesLegacy(etat);
 }
 
 export function possedeDejaModele(modeleId, etat = recupererEtatJeu()) {
-  return (etat.vaisseauxPossedes || []).some((vaisseau) => vaisseau.modeleId === modeleId)
+  return (etat.vaisseauxPossedes || []).some(
+    (vaisseau) => vaisseau.modeleId === modeleId,
+  );
 }
 
 export function peutChangerDeVaisseau(idVaisseau, etat = recupererEtatJeu()) {
-  if (etat.positionLocale !== 'station') {
-    return { ok: false, raison: 'Le changement de vaisseau n’est possible qu’en station.' }
+  if (etat.positionLocale !== "station") {
+    return {
+      ok: false,
+      raison: "Le changement de vaisseau n’est possible qu’en station.",
+    };
   }
 
   if (etat.navigation?.enVoyage) {
-    return { ok: false, raison: 'Impossible de changer de vaisseau pendant un trajet.' }
+    return {
+      ok: false,
+      raison: "Impossible de changer de vaisseau pendant un trajet.",
+    };
   }
 
   const vaisseauCible =
-    (etat.vaisseauxPossedes || []).find((vaisseau) => vaisseau.id === idVaisseau) || null
+    (etat.vaisseauxPossedes || []).find(
+      (vaisseau) => vaisseau.id === idVaisseau,
+    ) || null;
 
   if (!vaisseauCible) {
-    return { ok: false, raison: 'Vaisseau cible introuvable dans le hangar.' }
+    return { ok: false, raison: "Vaisseau cible introuvable dans le hangar." };
   }
 
   if (etat.vaisseauActifId === idVaisseau) {
-    return { ok: false, raison: 'Ce vaisseau est déjà actif.' }
+    return { ok: false, raison: "Ce vaisseau est déjà actif." };
   }
 
   if ((etat.vaisseau?.soute || 0) > vaisseauCible.souteMax) {
     return {
       ok: false,
-      raison: 'La soute actuelle dépasse la capacité maximale du vaisseau cible.',
-    }
+      raison:
+        "La soute actuelle dépasse la capacité maximale du vaisseau cible.",
+    };
   }
 
-  return { ok: true, raison: null }
+  return { ok: true, raison: null };
 }
 
 export function changerVaisseauActif(idVaisseau) {
-  const etat = recupererEtatJeu()
-  const validation = peutChangerDeVaisseau(idVaisseau, etat)
+  const etat = recupererEtatJeu();
+  const validation = peutChangerDeVaisseau(idVaisseau, etat);
 
   if (!validation.ok) {
-    ajouterAuJournal(validation.raison, 'evenements')
-    return false
+    ajouterAuJournal(validation.raison, "evenements");
+    return false;
   }
 
-  synchroniserFlotteDepuisVaisseauActif(etat)
+  synchroniserFlotteDepuisVaisseauActif(etat);
 
-  const ancienVaisseau = recupererVaisseauActif(etat)
-  const vaisseauCible = etat.vaisseauxPossedes.find((vaisseau) => vaisseau.id === idVaisseau)
-  const cargaisonActuelle = etat.vaisseau?.soute || 0
+  const ancienVaisseau = recupererVaisseauActif(etat);
+  const vaisseauCible = etat.vaisseauxPossedes.find(
+    (vaisseau) => vaisseau.id === idVaisseau,
+  );
+  const cargaisonActuelle = etat.vaisseau?.soute || 0;
 
   if (ancienVaisseau) {
-    ancienVaisseau.soute = 0
+    ancienVaisseau.soute = 0;
   }
 
-  vaisseauCible.soute = cargaisonActuelle
-  etat.vaisseauActifId = vaisseauCible.id
+  vaisseauCible.soute = cargaisonActuelle;
+  etat.vaisseauActifId = vaisseauCible.id;
 
-  synchroniserVaisseauActifDansEtat(etat)
+  synchroniserVaisseauActifDansEtat(etat);
 
   ajouterAuJournal(
     `Changement de châssis effectué : ${vaisseauCible.nom} désormais actif.`,
-    'evenements',
-  )
+    "evenements",
+  );
 
-  return true
+  return true;
 }
 
-export function recupererCatalogueVaisseauxStation(secteurId, etat = recupererEtatJeu()) {
-  if (secteurId !== 'ceinture_khepri') {
-    return []
+export function recupererCatalogueVaisseauxStation(
+  secteurId,
+  etat = recupererEtatJeu(),
+) {
+  if (secteurId !== "ceinture_khepri") {
+    return [];
   }
 
   return donneesVaisseaux
-    .filter((vaisseau) => vaisseau.id === 'hw_caravel')
+    .filter((vaisseau) => vaisseau.id === "hw_caravel")
     .map((modele) => ({
       ...modele,
       dejaPossede: possedeDejaModele(modele.id, etat),
-    }))
+    }));
 }
 
 export function peutAcheterVaisseau(modeleId, etat = recupererEtatJeu()) {
-  if (etat.positionLocale !== 'station') {
-    return { ok: false, raison: 'Achat de vaisseau possible uniquement en station.' }
+  if (etat.positionLocale !== "station") {
+    return {
+      ok: false,
+      raison: "Achat de vaisseau possible uniquement en station.",
+    };
   }
 
   if (etat.navigation?.enVoyage) {
-    return { ok: false, raison: 'Impossible d’acheter un vaisseau pendant un trajet.' }
+    return {
+      ok: false,
+      raison: "Impossible d’acheter un vaisseau pendant un trajet.",
+    };
   }
 
-  if (etat.secteurCourant?.id !== 'ceinture_khepri') {
-    return { ok: false, raison: 'Aucun marchand de vaisseaux disponible dans ce secteur.' }
+  if (etat.secteurCourant?.id !== "ceinture_khepri") {
+    return {
+      ok: false,
+      raison: "Aucun marchand de vaisseaux disponible dans ce secteur.",
+    };
   }
 
-  const modele = donneesVaisseaux.find((vaisseau) => vaisseau.id === modeleId)
+  const modele = donneesVaisseaux.find((vaisseau) => vaisseau.id === modeleId);
 
   if (!modele) {
-    return { ok: false, raison: 'Modèle de vaisseau introuvable.' }
+    return { ok: false, raison: "Modèle de vaisseau introuvable." };
   }
 
   if (possedeDejaModele(modeleId, etat)) {
-    return { ok: false, raison: 'Ce vaisseau est déjà présent dans votre hangar.' }
+    return {
+      ok: false,
+      raison: "Ce vaisseau est déjà présent dans votre hangar.",
+    };
   }
 
   if ((etat.ressources?.credits || 0) < (modele.prix || 0)) {
-    return { ok: false, raison: 'Crédits insuffisants pour cet achat.' }
+    return { ok: false, raison: "Crédits insuffisants pour cet achat." };
   }
 
-  return { ok: true, raison: null }
+  return { ok: true, raison: null };
 }
 
 export function acheterVaisseau(modeleId) {
-  const etat = recupererEtatJeu()
-  const validation = peutAcheterVaisseau(modeleId, etat)
+  const etat = recupererEtatJeu();
+  const validation = peutAcheterVaisseau(modeleId, etat);
 
   if (!validation.ok) {
-    ajouterAuJournal(validation.raison, 'commerce')
-    return false
+    ajouterAuJournal(validation.raison, "commerce");
+    return false;
   }
 
-  const modele = donneesVaisseaux.find((vaisseau) => vaisseau.id === modeleId)
+  const modele = donneesVaisseaux.find((vaisseau) => vaisseau.id === modeleId);
   const exemplairesExistants = etat.vaisseauxPossedes.filter(
     (vaisseau) => vaisseau.modeleId === modeleId,
-  ).length
-  const suffixe = String(exemplairesExistants + 1).padStart(3, '0')
-  const nouveauVaisseau = creerInstanceVaisseauDepuisModele(modeleId, suffixe)
+  ).length;
+  const suffixe = String(exemplairesExistants + 1).padStart(3, "0");
+  const nouveauVaisseau = creerInstanceVaisseauDepuisModele(modeleId, suffixe);
 
-  etat.ressources.credits -= modele.prix
-  etat.vaisseauxPossedes.push(normaliserVaisseauPossede(nouveauVaisseau))
+  etat.ressources.credits -= modele.prix;
+  etat.vaisseauxPossedes.push(normaliserVaisseauPossede(nouveauVaisseau));
 
   ajouterAuJournal(
     `Acquisition confirmée : ${modele.nom} ajouté au hangar pour ${modele.prix} cr.`,
-    'commerce',
-  )
+    "commerce",
+  );
 
-  return true
+  return true;
 }
 
-export function peutSouscrireAssuranceVaisseauActif(niveau, etat = recupererEtatJeu()) {
-  const vaisseauActif = recupererVaisseauActif(etat)
+export function peutSouscrireAssuranceVaisseauActif(
+  niveau,
+  etat = recupererEtatJeu(),
+) {
+  const vaisseauActif = recupererVaisseauActif(etat);
 
   if (!vaisseauActif) {
-    return { ok: false, raison: 'Aucun vaisseau actif disponible.' }
+    return { ok: false, raison: "Aucun vaisseau actif disponible." };
   }
 
-  if (etat.positionLocale !== 'station') {
-    return { ok: false, raison: 'La souscription d’assurance est possible uniquement en station.' }
+  if (etat.positionLocale !== "station") {
+    return {
+      ok: false,
+      raison: "La souscription d’assurance est possible uniquement en station.",
+    };
   }
 
   if (etat.navigation?.enVoyage) {
-    return { ok: false, raison: 'Impossible de modifier une assurance pendant un trajet.' }
+    return {
+      ok: false,
+      raison: "Impossible de modifier une assurance pendant un trajet.",
+    };
   }
 
-  const niveauxAutorises = ['aucune', 'tiers', 'standard', 'premium', 'elite']
+  const niveauxAutorises = ["aucune", "tiers", "standard", "premium", "elite"];
 
   if (!niveauxAutorises.includes(niveau)) {
-    return { ok: false, raison: 'Niveau d’assurance invalide.' }
+    return { ok: false, raison: "Niveau d’assurance invalide." };
   }
 
-  const contratActif = estContratAssuranceActif(vaisseauActif)
+  const contratActif = estContratAssuranceActif(vaisseauActif);
 
-  if (niveau === 'aucune' && vaisseauActif.assuranceNiveau === 'aucune') {
-    return { ok: false, raison: 'Aucun contrat actif à résilier.' }
+  if (niveau === "aucune" && vaisseauActif.assuranceNiveau === "aucune") {
+    return { ok: false, raison: "Aucun contrat actif à résilier." };
   }
 
-  if (niveau !== 'aucune' && vaisseauActif.assuranceNiveau === niveau && contratActif) {
-    return { ok: false, raison: 'Ce contrat est déjà actif sur le vaisseau.' }
+  if (
+    niveau !== "aucune" &&
+    vaisseauActif.assuranceNiveau === niveau &&
+    contratActif
+  ) {
+    return { ok: false, raison: "Ce contrat est déjà actif sur le vaisseau." };
   }
 
-  const cout = calculerCoutAssurance(vaisseauActif.modeleId, niveau)
+  const cout = calculerCoutAssurance(vaisseauActif.modeleId, niveau);
 
   if ((etat.ressources?.credits || 0) < cout) {
-    return { ok: false, raison: 'Crédits insuffisants pour cette formule d’assurance.' }
+    return {
+      ok: false,
+      raison: "Crédits insuffisants pour cette formule d’assurance.",
+    };
   }
 
-  return { ok: true, raison: null, cout }
+  return { ok: true, raison: null, cout };
 }
 
 export function souscrireAssuranceVaisseauActif(niveau) {
-  const etat = recupererEtatJeu()
-  const validation = peutSouscrireAssuranceVaisseauActif(niveau, etat)
+  const etat = recupererEtatJeu();
+  const validation = peutSouscrireAssuranceVaisseauActif(niveau, etat);
 
   if (!validation.ok) {
-    ajouterAuJournal(validation.raison, 'commerce')
-    return false
+    ajouterAuJournal(validation.raison, "commerce");
+    return false;
   }
 
-  synchroniserFlotteDepuisVaisseauActif(etat)
+  synchroniserFlotteDepuisVaisseauActif(etat);
 
-  const tickCourant = recupererTickCourant()
-  const vaisseauActif = recupererVaisseauActif(etat)
+  const tickCourant = recupererTickCourant();
+  const vaisseauActif = recupererVaisseauActif(etat);
 
-  if (niveau === 'aucune') {
-    reinitialiserContratAssuranceVaisseau(vaisseauActif)
+  if (niveau === "aucune") {
+    reinitialiserContratAssuranceVaisseau(vaisseauActif);
 
-    synchroniserVaisseauActifDansEtat(etat)
+    synchroniserVaisseauActifDansEtat(etat);
 
-    ajouterAuJournal(`Résiliation du contrat d’assurance pour ${vaisseauActif.nom}.`, 'commerce')
+    ajouterAuJournal(
+      `Résiliation du contrat d’assurance pour ${vaisseauActif.nom}.`,
+      "commerce",
+    );
 
-    return true
+    return true;
   }
 
-  vaisseauActif.assuranceNiveau = niveau
-  vaisseauActif.assuranceSouscriptionTick = tickCourant
-  vaisseauActif.assuranceExpirationTick = tickCourant + DUREE_CONTRAT_ASSURANCE_TICKS
-  etat.ressources.credits -= validation.cout
+  vaisseauActif.assuranceNiveau = niveau;
+  vaisseauActif.assuranceSouscriptionTick = tickCourant;
+  vaisseauActif.assuranceExpirationTick =
+    tickCourant + DUREE_CONTRAT_ASSURANCE_TICKS;
+  etat.ressources.credits -= validation.cout;
 
-  synchroniserVaisseauActifDansEtat(etat)
+  synchroniserVaisseauActifDansEtat(etat);
 
   ajouterAuJournal(
     `Contrat d’assurance ${recupererLibelleAssurance(niveau)} souscrit pour ${vaisseauActif.nom} (${validation.cout} cr, validité 720 ticks).`,
-    'commerce',
-  )
+    "commerce",
+  );
 
-  return true
+  return true;
 }
 
-export function estVaisseauIndemnisable(vaisseau, tickCourant = recupererTickCourant()) {
+export function estVaisseauIndemnisable(
+  vaisseau,
+  tickCourant = recupererTickCourant(),
+) {
   if (!vaisseau) {
-    return false
+    return false;
   }
 
-  return estContratAssuranceActif(vaisseau, tickCourant)
+  return estContratAssuranceActif(vaisseau, tickCourant);
 }
 
-export function recupererTauxIndemnisationVaisseau(vaisseau, tickCourant = recupererTickCourant()) {
+export function recupererTauxIndemnisationVaisseau(
+  vaisseau,
+  tickCourant = recupererTickCourant(),
+) {
   if (!estVaisseauIndemnisable(vaisseau, tickCourant)) {
-    return 0
+    return 0;
   }
 
-  return recupererTauxRemboursementAssurance(vaisseau.assuranceNiveau)
+  return recupererTauxRemboursementAssurance(vaisseau.assuranceNiveau);
 }
 
 export function calculerMontantIndemnisationVaisseau(
   vaisseau,
   tickCourant = recupererTickCourant(),
 ) {
-  const tauxIndemnisation = recupererTauxIndemnisationVaisseau(vaisseau, tickCourant)
-  const valeurMarchande = recupererValeurMarchandeVaisseau(vaisseau)
+  const tauxIndemnisation = recupererTauxIndemnisationVaisseau(
+    vaisseau,
+    tickCourant,
+  );
+  const valeurMarchande = recupererValeurMarchandeVaisseau(vaisseau);
 
   if (tauxIndemnisation <= 0 || valeurMarchande <= 0) {
-    return 0
+    return 0;
   }
 
-  return Math.max(0, Math.round(valeurMarchande * tauxIndemnisation))
+  return Math.max(0, Math.round(valeurMarchande * tauxIndemnisation));
 }
 
-export function peutDeclencherIndemnisationAssuranceVaisseauActif(etat = recupererEtatJeu()) {
-  const vaisseauActif = recupererVaisseauActif(etat)
+export function peutDeclencherIndemnisationAssuranceVaisseauActif(
+  etat = recupererEtatJeu(),
+) {
+  const vaisseauActif = recupererVaisseauActif(etat);
 
   if (!vaisseauActif) {
     return {
       ok: false,
-      raison: 'Aucun vaisseau actif disponible pour une indemnisation.',
+      raison: "Aucun vaisseau actif disponible pour une indemnisation.",
       montant: 0,
-    }
+    };
   }
 
   if (!estVaisseauIndemnisable(vaisseauActif)) {
     return {
       ok: false,
-      raison: 'Aucun contrat actif ne permet une indemnisation sur ce vaisseau.',
+      raison:
+        "Aucun contrat actif ne permet une indemnisation sur ce vaisseau.",
       montant: 0,
-    }
+    };
   }
 
-  const montant = calculerMontantIndemnisationVaisseau(vaisseauActif)
+  const montant = calculerMontantIndemnisationVaisseau(vaisseauActif);
 
   if (montant <= 0) {
     return {
       ok: false,
-      raison: 'Le contrat actif ne permet aucune indemnisation exploitable.',
+      raison: "Le contrat actif ne permet aucune indemnisation exploitable.",
       montant: 0,
-    }
+    };
   }
 
   return {
     ok: true,
     raison: null,
     montant,
-  }
+  };
 }
 
 export function declencherIndemnisationAssuranceVaisseauActif() {
-  const etat = recupererEtatJeu()
-  synchroniserFlotteDepuisVaisseauActif(etat)
+  const etat = recupererEtatJeu();
+  synchroniserFlotteDepuisVaisseauActif(etat);
 
-  const vaisseauActif = recupererVaisseauActif(etat)
-  const validation = peutDeclencherIndemnisationAssuranceVaisseauActif(etat)
+  const vaisseauActif = recupererVaisseauActif(etat);
+  const validation = peutDeclencherIndemnisationAssuranceVaisseauActif(etat);
 
   if (!validation.ok || !vaisseauActif) {
     return {
       ok: false,
       raison: validation.raison,
       montant: 0,
-    }
+    };
   }
 
-  const niveauAvantIndemnisation = vaisseauActif.assuranceNiveau
-  const montant = validation.montant
+  const niveauAvantIndemnisation = vaisseauActif.assuranceNiveau;
+  const montant = validation.montant;
 
-  etat.ressources.credits += montant
-  reinitialiserContratAssuranceVaisseau(vaisseauActif)
+  etat.ressources.credits += montant;
+  reinitialiserContratAssuranceVaisseau(vaisseauActif);
 
-  synchroniserVaisseauActifDansEtat(etat)
+  synchroniserVaisseauActifDansEtat(etat);
 
   ajouterAuJournal(
     `Indemnisation d’assurance ${recupererLibelleAssurance(niveauAvantIndemnisation)} versée pour ${vaisseauActif.nom} : +${montant} cr.`,
-    'commerce',
-  )
+    "commerce",
+  );
 
   return {
     ok: true,
     raison: null,
     montant,
-  }
+  };
 }


### PR DESCRIPTION
## Objet
Correction d’une incohérence d’affichage dans le panneau **Services de station > Ravitaillement**.

## Problème
Le panneau de ravitaillement s’appuyait sur `ressources.carburant`, ce qui provoquait un affichage erroné du niveau de carburant après réinitialisation ou dans certains cas de synchronisation d’état.

Exemple :
- panneau vaisseau : `10 / 10`
- panneau ravitaillement : `0 / 10`

Cette incohérence pouvait conduire à une lecture trompeuse de l’état réel du vaisseau.

## Correction apportée
Le composant `StationServicesPanel.vue` utilise désormais :
- `vaisseau.carburant` pour le carburant actuel ;
- `vaisseau.carburantMax` pour la capacité maximale.

Les calculs suivants ont été ajustés :
- carburant actuel ;
- carburant manquant ;
- coût du plein ;
- affichage du bloc de ravitaillement.

## Impact
- affichage désormais cohérent entre le panneau vaisseau et le panneau de ravitaillement ;
- suppression du faux état de réservoir vide au démarrage ;
- comportement visuel conforme à l’état réel du vaisseau actif.

## Fichier modifié
- `src/components/StationServicesPanel.vue`