### PR TITLE
v0.3.15-129 : balance: rééquilibrer les durées et coûts des trajets

### DIFF
--- a/src/data/trajets.json
+++ b/src/data/trajets.json
@@ -3,98 +3,98 @@
     "id": "ceinture_khepri__anneau_demeter",
     "origine": "ceinture_khepri",
     "destination": "anneau_demeter",
-    "coutCarburant": 2,
-    "tempsTrajet": 3
+    "coutCarburant": 3,
+    "tempsTrajet": 5
   },
   {
     "id": "anneau_demeter__ceinture_khepri",
     "origine": "anneau_demeter",
     "destination": "ceinture_khepri",
-    "coutCarburant": 2,
-    "tempsTrajet": 3
+    "coutCarburant": 3,
+    "tempsTrajet": 5
   },
   {
     "id": "anneau_demeter__forge_tantalus",
     "origine": "anneau_demeter",
     "destination": "forge_tantalus",
-    "coutCarburant": 2,
-    "tempsTrajet": 3
+    "coutCarburant": 3,
+    "tempsTrajet": 5
   },
   {
     "id": "forge_tantalus__anneau_demeter",
     "origine": "forge_tantalus",
     "destination": "anneau_demeter",
-    "coutCarburant": 2,
-    "tempsTrajet": 3
+    "coutCarburant": 3,
+    "tempsTrajet": 5
   },
   {
     "id": "forge_tantalus__banc_persephone",
     "origine": "forge_tantalus",
     "destination": "banc_persephone",
-    "coutCarburant": 2,
-    "tempsTrajet": 3
+    "coutCarburant": 3,
+    "tempsTrajet": 5
   },
   {
     "id": "banc_persephone__forge_tantalus",
     "origine": "banc_persephone",
     "destination": "forge_tantalus",
-    "coutCarburant": 2,
-    "tempsTrajet": 3
+    "coutCarburant": 3,
+    "tempsTrajet": 5
   },
   {
     "id": "banc_persephone__drift_nyx",
     "origine": "banc_persephone",
     "destination": "drift_nyx",
-    "coutCarburant": 2,
-    "tempsTrajet": 3
+    "coutCarburant": 3,
+    "tempsTrajet": 5
   },
   {
     "id": "drift_nyx__banc_persephone",
     "origine": "drift_nyx",
     "destination": "banc_persephone",
-    "coutCarburant": 2,
-    "tempsTrajet": 3
+    "coutCarburant": 3,
+    "tempsTrajet": 5
   },
   {
     "id": "drift_nyx__nuee_hecate",
     "origine": "drift_nyx",
     "destination": "nuee_hecate",
-    "coutCarburant": 2,
-    "tempsTrajet": 3
+    "coutCarburant": 3,
+    "tempsTrajet": 5
   },
   {
     "id": "nuee_hecate__drift_nyx",
     "origine": "nuee_hecate",
     "destination": "drift_nyx",
-    "coutCarburant": 2,
-    "tempsTrajet": 3
+    "coutCarburant": 3,
+    "tempsTrajet": 5
   },
   {
     "id": "ceinture_khepri__forge_tantalus",
     "origine": "ceinture_khepri",
     "destination": "forge_tantalus",
-    "coutCarburant": 3,
-    "tempsTrajet": 4
+    "coutCarburant": 5,
+    "tempsTrajet": 6
   },
   {
     "id": "forge_tantalus__ceinture_khepri",
     "origine": "forge_tantalus",
     "destination": "ceinture_khepri",
-    "coutCarburant": 3,
-    "tempsTrajet": 4
+    "coutCarburant": 5,
+    "tempsTrajet": 6
   },
   {
     "id": "banc_persephone__nuee_hecate",
     "origine": "banc_persephone",
     "destination": "nuee_hecate",
-    "coutCarburant": 3,
-    "tempsTrajet": 4
+    "coutCarburant": 5,
+    "tempsTrajet": 6
   },
   {
     "id": "nuee_hecate__banc_persephone",
     "origine": "nuee_hecate",
     "destination": "banc_persephone",
-    "coutCarburant": 3,
-    "tempsTrajet": 4
+    "coutCarburant": 5,
+    "tempsTrajet": 6
   }
 ]


### PR DESCRIPTION
## Objet
Cette MR implémente le ticket #140 en rééquilibrant les durées et consommations des trajets inter-sectoriels.

## Objectif
Rendre la phase de voyage plus perceptible dans le rythme de jeu, en cohérence avec l’animation de transit et la barre de progression ajoutées précédemment.

## Modifications réalisées
- augmentation des durées de trajet avec un multiplicateur cible de ×1,5
- augmentation des coûts carburant avec un multiplicateur cible de ×1,5
- arrondi des valeurs au supérieur pour conserver des valeurs entières lisibles
- conservation de la structure actuelle du réseau de trajets
- aucune nouvelle route ajoutée

## Règles appliquées
- `2 carburant / 3 ticks` devient `3 carburant / 5 ticks`
- `3 carburant / 4 ticks` devient `5 carburant / 6 ticks`

## Choix d’implémentation
Le ticket se limite à la modification des données de trajet existantes.

Aucun changement n’est apporté :
- au système de navigation
- au modèle de carburant
- aux sons ou animations de voyage
- aux routes disponibles
- aux futurs incidents de transit

## Fichier concerné
- `src/data/trajets.json`

## Tests manuels
- vérifier l’affichage des nouvelles durées dans le panneau Navigation
- vérifier l’affichage des nouveaux coûts carburant
- lancer un trajet court et vérifier :
  - coût de 3 carburant
  - durée de 5 ticks
  - progression correcte tick par tick
- lancer un trajet long et vérifier :
  - coût de 5 carburant
  - durée de 6 ticks
  - progression correcte tick par tick
- vérifier que le carburant est bien prélevé sur le vaisseau actif
- vérifier qu’aucun nouveau trajet n’apparaît

## Ticket lié
- #140